### PR TITLE
Fix typos across docs and code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@
   - Renamed and replaced the legacy “Last Death” system with a new “Death Points” feature.
   - Introduced a dedicated GUI for managing deathpoints.
   - Integrated DeathPointsManager and DeathPointsCommand to streamline deathpoint navigation.
-  - Made the deathchest more private to be only edited and claimbed by the owner.
+   - Made the deathchest more private to be only edited and claimed by the owner.
   - Added holograms above the deathchest.
 - **Waypoints GUI:**
-  - Fixed options title for "reaname" which was "remove" previously
+  - Fixed options title for "rename" which was "remove" previously
   - Re-Open GUI after setting a custom icon
 - **AFK-Time Setting:**
   - validate input to make sure it is an integer

--- a/src/main/java/com/daveestar/bettervanilla/manager/DeathPointsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/DeathPointsManager.java
@@ -30,7 +30,7 @@ public class DeathPointsManager {
 
   public DeathPointsManager(Config config) {
     _config = config;
-    _fileConfig = config.getFileCfgrn();
+    _fileConfig = config.getFileConfig();
   }
 
   public void addDeathPoint(Player p, Location loc) {

--- a/src/main/java/com/daveestar/bettervanilla/manager/PermissionsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/PermissionsManager.java
@@ -15,7 +15,7 @@ public class PermissionsManager {
   private final String _DEFAULT_GROUP_NAME = "default";
 
   private final Config _config;
-  private final FileConfiguration _fileCfgn;
+  private final FileConfiguration _fileConfig;
   private final JavaPlugin plugin;
 
   private final Map<UUID, PermissionAttachment> activeAttachments = new HashMap<>();
@@ -23,23 +23,23 @@ public class PermissionsManager {
   public PermissionsManager(Config config) {
     plugin = Main.getInstance();
     _config = config;
-    _fileCfgn = config.getFileCfgrn();
+    _fileConfig = config.getFileConfig();
 
     _loadConfig();
   }
 
   private void _loadConfig() {
     // create sections for groups and users if not present
-    if (!_fileCfgn.contains("groups")) {
-      _fileCfgn.createSection("groups");
+    if (!_fileConfig.contains("groups")) {
+      _fileConfig.createSection("groups");
     }
 
-    if (!_fileCfgn.contains("users")) {
-      _fileCfgn.createSection("users");
+    if (!_fileConfig.contains("users")) {
+      _fileConfig.createSection("users");
     }
 
     // ensure the default group exists
-    if (!_fileCfgn.contains("groups." + _DEFAULT_GROUP_NAME)) {
+    if (!_fileConfig.contains("groups." + _DEFAULT_GROUP_NAME)) {
       addGroup(_DEFAULT_GROUP_NAME);
     }
 
@@ -55,57 +55,57 @@ public class PermissionsManager {
   // ------------------------
 
   public void addGroup(String groupName) {
-    if (!_fileCfgn.contains("groups." + groupName)) {
-      _fileCfgn.createSection("groups." + groupName);
-      _fileCfgn.set("groups." + groupName + ".permissions", new ArrayList<String>());
+    if (!_fileConfig.contains("groups." + groupName)) {
+      _fileConfig.createSection("groups." + groupName);
+      _fileConfig.set("groups." + groupName + ".permissions", new ArrayList<String>());
       _save();
     }
   }
 
   public void removeGroup(String groupName) {
-    _fileCfgn.set("groups." + groupName, null);
+    _fileConfig.set("groups." + groupName, null);
     _save();
   }
 
   public void addPermissionToGroup(String groupName, String permission) {
     addGroup(groupName);
 
-    List<String> perms = _fileCfgn.getStringList("groups." + groupName + ".permissions");
+    List<String> perms = _fileConfig.getStringList("groups." + groupName + ".permissions");
 
     if (!perms.contains(permission)) {
       perms.add(permission);
-      _fileCfgn.set("groups." + groupName + ".permissions", perms);
+      _fileConfig.set("groups." + groupName + ".permissions", perms);
       _save();
     }
   }
 
   public void removePermissionFromGroup(String groupName, String permission) {
-    if (_fileCfgn.contains("groups." + groupName + ".permissions")) {
-      List<String> perms = _fileCfgn.getStringList("groups." + groupName + ".permissions");
+    if (_fileConfig.contains("groups." + groupName + ".permissions")) {
+      List<String> perms = _fileConfig.getStringList("groups." + groupName + ".permissions");
 
       if (perms.contains(permission)) {
         perms.remove(permission);
-        _fileCfgn.set("groups." + groupName + ".permissions", perms);
+        _fileConfig.set("groups." + groupName + ".permissions", perms);
         _save();
       }
     }
   }
 
   public boolean hasGroupPermission(String groupName, String permission) {
-    List<String> perms = _fileCfgn.getStringList("groups." + groupName + ".permissions");
+    List<String> perms = _fileConfig.getStringList("groups." + groupName + ".permissions");
     return perms.contains(permission);
   }
 
   public Set<String> getAllGroupNames() {
-    if (_fileCfgn.contains("groups")) {
-      return _fileCfgn.getConfigurationSection("groups").getKeys(false);
+    if (_fileConfig.contains("groups")) {
+      return _fileConfig.getConfigurationSection("groups").getKeys(false);
     }
 
     return new HashSet<>();
   }
 
   public List<String> getGroupPermissions(String groupName) {
-    return _fileCfgn.getStringList("groups." + groupName + ".permissions");
+    return _fileConfig.getStringList("groups." + groupName + ".permissions");
   }
 
   // -----------------------
@@ -117,18 +117,18 @@ public class PermissionsManager {
 
     String uuid = p.getUniqueId().toString();
 
-    _fileCfgn.set("users." + uuid + ".group", groupName);
+    _fileConfig.set("users." + uuid + ".group", groupName);
     _save();
   }
 
   public void addPermissionToUser(OfflinePlayer p, String permission) {
     String uuid = p.getUniqueId().toString();
 
-    List<String> perms = _fileCfgn.getStringList("users." + uuid + ".permissions");
+    List<String> perms = _fileConfig.getStringList("users." + uuid + ".permissions");
 
     if (!perms.contains(permission)) {
       perms.add(permission);
-      _fileCfgn.set("users." + uuid + ".permissions", perms);
+      _fileConfig.set("users." + uuid + ".permissions", perms);
       _save();
     }
   }
@@ -136,11 +136,11 @@ public class PermissionsManager {
   public void removePermissionFromUser(OfflinePlayer p, String permission) {
     String uuid = p.getUniqueId().toString();
 
-    List<String> perms = _fileCfgn.getStringList("users." + uuid + ".permissions");
+    List<String> perms = _fileConfig.getStringList("users." + uuid + ".permissions");
 
     if (perms.contains(permission)) {
       perms.remove(permission);
-      _fileCfgn.set("users." + uuid + ".permissions", perms);
+      _fileConfig.set("users." + uuid + ".permissions", perms);
       _save();
     }
   }
@@ -148,13 +148,13 @@ public class PermissionsManager {
   public boolean hasUserPermission(OfflinePlayer p, String permission) {
     String uuid = p.getUniqueId().toString();
 
-    List<String> perms = _fileCfgn.getStringList("users." + uuid + ".permissions");
+    List<String> perms = _fileConfig.getStringList("users." + uuid + ".permissions");
     return perms.contains(permission);
   }
 
   public Set<String> getAllUserIds() {
-    if (_fileCfgn.contains("users")) {
-      return _fileCfgn.getConfigurationSection("users").getKeys(false);
+    if (_fileConfig.contains("users")) {
+      return _fileConfig.getConfigurationSection("users").getKeys(false);
     }
 
     return new HashSet<>();
@@ -163,13 +163,13 @@ public class PermissionsManager {
   public List<String> getUserPermissions(OfflinePlayer p) {
     String uuid = p.getUniqueId().toString();
 
-    return _fileCfgn.getStringList("users." + uuid + ".permissions");
+    return _fileConfig.getStringList("users." + uuid + ".permissions");
   }
 
   public String getUserGroup(OfflinePlayer p) {
     String uuid = p.getUniqueId().toString();
 
-    return _fileCfgn.getString("users." + uuid + ".group", _DEFAULT_GROUP_NAME);
+    return _fileConfig.getString("users." + uuid + ".group", _DEFAULT_GROUP_NAME);
   }
 
   public List<String> getEffectivePermissions(OfflinePlayer p) {
@@ -178,12 +178,12 @@ public class PermissionsManager {
     Set<String> effectivePermissions = new HashSet<>();
 
     // get group permissions (default if no group is set).
-    String group = _fileCfgn.getString("users." + uuid + ".group", _DEFAULT_GROUP_NAME);
-    List<String> groupPerms = _fileCfgn.getStringList("groups." + group + ".permissions");
+    String group = _fileConfig.getString("users." + uuid + ".group", _DEFAULT_GROUP_NAME);
+    List<String> groupPerms = _fileConfig.getStringList("groups." + group + ".permissions");
     effectivePermissions.addAll(groupPerms);
 
     // overlay user-specific permissions.
-    List<String> userPerms = _fileCfgn.getStringList("users." + uuid + ".permissions");
+    List<String> userPerms = _fileConfig.getStringList("users." + uuid + ".permissions");
     effectivePermissions.addAll(userPerms);
 
     return new ArrayList<>(effectivePermissions);
@@ -195,9 +195,9 @@ public class PermissionsManager {
   public void onPlayerJoined(Player p) {
     String uuid = p.getUniqueId().toString();
 
-    if (!_fileCfgn.contains("users." + uuid)) {
-      _fileCfgn.createSection("users." + uuid);
-      _fileCfgn.set("users." + uuid + ".group", _DEFAULT_GROUP_NAME);
+    if (!_fileConfig.contains("users." + uuid)) {
+      _fileConfig.createSection("users." + uuid);
+      _fileConfig.set("users." + uuid + ".group", _DEFAULT_GROUP_NAME);
       _save();
     }
 

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -7,84 +7,84 @@ import com.daveestar.bettervanilla.utils.Config;
 
 public class SettingsManager {
   private Config _config;
-  private FileConfiguration _fileCfgn;
+  private FileConfiguration _fileConfig;
 
   public SettingsManager(Config config) {
     _config = config;
-    _fileCfgn = config.getFileCfgrn();
+    _fileConfig = config.getFileConfig();
   }
 
   // USER SETTINGS
   public boolean getToggleLocation(Player p) {
-    return _fileCfgn.getBoolean(p.getUniqueId() + ".togglelocation");
+    return _fileConfig.getBoolean(p.getUniqueId() + ".togglelocation");
   }
 
   public void setToggleLocation(Player p, boolean value) {
-    _fileCfgn.set(p.getUniqueId() + ".togglelocation", value);
+    _fileConfig.set(p.getUniqueId() + ".togglelocation", value);
     _config.save();
   }
 
   public boolean getToggleCompass(Player p) {
-    return _fileCfgn.getBoolean(p.getUniqueId() + ".togglecompass");
+    return _fileConfig.getBoolean(p.getUniqueId() + ".togglecompass");
   }
 
   public void setToggleCompass(Player p, boolean value) {
-    _fileCfgn.set(p.getUniqueId() + ".togglecompass", value);
+    _fileConfig.set(p.getUniqueId() + ".togglecompass", value);
     _config.save();
   }
 
   // GLOBAL SETTINGS
   public boolean getMaintenance() {
-    return _fileCfgn.getBoolean("global.maintenance.value", false);
+    return _fileConfig.getBoolean("global.maintenance.value", false);
   }
 
   public String getMaintenanceMessage() {
-    return _fileCfgn.getString("global.maintenance.message", "");
+    return _fileConfig.getString("global.maintenance.message", "");
   }
 
   public void setMaintenance(boolean value, String message) {
-    _fileCfgn.set("global.maintenance.value", value);
+    _fileConfig.set("global.maintenance.value", value);
 
     if (message != null) {
-      _fileCfgn.set("global.maintenance.message", message);
+      _fileConfig.set("global.maintenance.message", message);
     }
 
     _config.save();
   }
 
   public boolean getToggleCreeperDamage() {
-    return _fileCfgn.getBoolean("global.creeperdamage", true);
+    return _fileConfig.getBoolean("global.creeperdamage", true);
   }
 
   public void setToggleCreeperDamage(boolean value) {
-    _fileCfgn.set("global.creeperdamage", value);
+    _fileConfig.set("global.creeperdamage", value);
     _config.save();
   }
 
   public boolean getToggleEnd() {
-    return _fileCfgn.getBoolean("global.toggleend", false);
+    return _fileConfig.getBoolean("global.toggleend", false);
   }
 
   public void setToggleEnd(boolean value) {
-    _fileCfgn.set("global.toggleend", value);
+    _fileConfig.set("global.toggleend", value);
     _config.save();
   }
 
   public boolean getSleepingRain() {
-    return _fileCfgn.getBoolean("global.sleepingrain", false);
+    return _fileConfig.getBoolean("global.sleepingrain", false);
   }
 
   public void setSleepingRain(boolean value) {
-    _fileCfgn.set("global.sleepingrain", value);
+    _fileConfig.set("global.sleepingrain", value);
     _config.save();
   }
 
   public int getAFKTime() {
-    return _fileCfgn.getInt("global.afktime", 10);
+    return _fileConfig.getInt("global.afktime", 10);
   }
 
   public void setAFKTime(int value) {
-    _fileCfgn.set("global.afktime", value);
+    _fileConfig.set("global.afktime", value);
     _config.save();
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/TimerManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/TimerManager.java
@@ -36,7 +36,7 @@ public class TimerManager {
     _plugin = Main.getInstance();
 
     _config = config;
-    _fileConfig = config.getFileCfgrn();
+    _fileConfig = config.getFileConfig();
 
     _loadConfiguration();
     _initializePlayerTimers();

--- a/src/main/java/com/daveestar/bettervanilla/manager/WaypointsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/WaypointsManager.java
@@ -16,15 +16,15 @@ import com.daveestar.bettervanilla.utils.Config;
 
 public class WaypointsManager {
   private Config _config;
-  private FileConfiguration _fileCfgn;
+  private FileConfiguration _fileConfig;
 
   public WaypointsManager(Config config) {
     _config = config;
-    _fileCfgn = config.getFileCfgrn();
+    _fileConfig = config.getFileConfig();
   }
 
   public List<String> getWaypoints(String worldName) {
-    ConfigurationSection waypointsCfgnSection = _fileCfgn.getConfigurationSection(worldName);
+    ConfigurationSection waypointsCfgnSection = _fileConfig.getConfigurationSection(worldName);
     Set<String> allWaypointNames = null;
 
     if (waypointsCfgnSection != null) {
@@ -43,7 +43,7 @@ public class WaypointsManager {
   }
 
   public HashMap<String, Integer> getWaypointByName(String worldName, String waypointName) {
-    ConfigurationSection waypoint = _fileCfgn.getConfigurationSection(worldName + "." + waypointName);
+    ConfigurationSection waypoint = _fileConfig.getConfigurationSection(worldName + "." + waypointName);
 
     HashMap<String, Integer> coordinates = new HashMap<String, Integer>();
 
@@ -55,50 +55,50 @@ public class WaypointsManager {
   }
 
   public Boolean checkWaypointExists(String worldName, String waypointName) {
-    return _fileCfgn.contains(worldName + "." + waypointName);
+    return _fileConfig.contains(worldName + "." + waypointName);
   }
 
   public void addWaypoint(String worldName, String waypointName, Integer x, Integer y, Integer z) {
-    _fileCfgn.set(worldName + "." + waypointName + ".x", x);
-    _fileCfgn.set(worldName + "." + waypointName + ".y", y);
-    _fileCfgn.set(worldName + "." + waypointName + ".z", z);
+    _fileConfig.set(worldName + "." + waypointName + ".x", x);
+    _fileConfig.set(worldName + "." + waypointName + ".y", y);
+    _fileConfig.set(worldName + "." + waypointName + ".z", z);
 
     _config.save();
   }
 
   public void removeWaypoint(String worldName, String waypointName) {
-    _fileCfgn.set(worldName + "." + waypointName, null);
+    _fileConfig.set(worldName + "." + waypointName, null);
 
     _config.save();
   }
 
   public void renameWaypoint(String worldName, String oldName, String newName) {
-    ConfigurationSection waypoint = _fileCfgn.getConfigurationSection(worldName + "." + oldName);
+    ConfigurationSection waypoint = _fileConfig.getConfigurationSection(worldName + "." + oldName);
     if (waypoint != null) {
-      _fileCfgn.set(worldName + "." + newName + ".x", waypoint.getInt("x"));
-      _fileCfgn.set(worldName + "." + newName + ".y", waypoint.getInt("y"));
-      _fileCfgn.set(worldName + "." + newName + ".z", waypoint.getInt("z"));
+      _fileConfig.set(worldName + "." + newName + ".x", waypoint.getInt("x"));
+      _fileConfig.set(worldName + "." + newName + ".y", waypoint.getInt("y"));
+      _fileConfig.set(worldName + "." + newName + ".z", waypoint.getInt("z"));
 
-      if (_fileCfgn.contains(worldName + "." + oldName + ".icon")) {
-        Object iconData = _fileCfgn.get(worldName + "." + oldName + ".icon");
-        _fileCfgn.set(worldName + "." + newName + ".icon", iconData);
+      if (_fileConfig.contains(worldName + "." + oldName + ".icon")) {
+        Object iconData = _fileConfig.get(worldName + "." + oldName + ".icon");
+        _fileConfig.set(worldName + "." + newName + ".icon", iconData);
       }
 
-      _fileCfgn.set(worldName + "." + oldName, null);
+      _fileConfig.set(worldName + "." + oldName, null);
       _config.save();
     }
   }
 
   public void setWaypointIcon(String worldName, String waypointName, ItemStack iconItem) {
     Map<String, Object> serializedIcon = iconItem.serialize();
-    _fileCfgn.set(worldName + "." + waypointName + ".icon", serializedIcon);
+    _fileConfig.set(worldName + "." + waypointName + ".icon", serializedIcon);
     _config.save();
   }
 
   public ItemStack getWaypointIcon(String worldName, String waypointName) {
     String path = worldName + "." + waypointName + ".icon";
-    if (_fileCfgn.contains(path)) {
-      Object raw = _fileCfgn.get(path);
+    if (_fileConfig.contains(path)) {
+      Object raw = _fileConfig.get(path);
       Map<String, Object> map = null;
 
       if (raw instanceof Map) {

--- a/src/main/java/com/daveestar/bettervanilla/utils/Config.java
+++ b/src/main/java/com/daveestar/bettervanilla/utils/Config.java
@@ -37,7 +37,7 @@ public class Config {
     return _file;
   }
 
-  public FileConfiguration getFileCfgrn() {
+  public FileConfiguration getFileConfig() {
     return _fileConfiguration;
   }
 


### PR DESCRIPTION
## Summary
- fix spelling mistakes in CHANGELOG
- rename `getFileCfgrn` helper to `getFileConfig`
- rename related config fields across managers

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e7eef3fc8320b143450665b19eca