### PR TITLE
Fix coords navigation range check

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/commands/WaypointsCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/WaypointsCommand.java
@@ -219,6 +219,18 @@ public class WaypointsCommand implements TabExecutor {
       int z = Integer.parseInt(args[3]);
 
       Location destination = new Location(p.getWorld(), x, y, z);
+      Location playerLocation = p.getLocation().toBlockLocation();
+
+      if (playerLocation.distance(destination.toBlockLocation()) <= 25) {
+        _navigationManager.stopNavigation(p);
+        _actionBarManager.sendActionBarOnce(p,
+            ChatColor.YELLOW + "" + ChatColor.BOLD + "Custom Coordinates: " + ChatColor.RESET
+                + ChatColor.YELLOW + "X: " + ChatColor.GRAY + x + ChatColor.YELLOW + " Y: "
+                + ChatColor.GRAY + y + ChatColor.YELLOW + " Z: " + ChatColor.GRAY + z
+                + ChatColor.GRAY + " is within 25 blocks!");
+        return;
+      }
+
       _settingsManager.setToggleLocation(p, false);
       NavigationData navigationData = new NavigationData("Custom Coordinates", destination, NavigationType.WAYPOINT,
           Color.YELLOW);


### PR DESCRIPTION
## Summary
- cancel `/waypoints coords` navigation if the player is already within 25 blocks of the destination
- show the coordinates in the cancel message

## Testing
- `mvn -q -DskipTests=true package` *(fails: mvn not found)*


------
https://chatgpt.com/codex/tasks/task_e_6842ed8727dc83209f06ce75d3174745