### PR TITLE
Add settings GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ _(Scroll down for the complete feature & command list.)_
 
 ### Admin & Server
 
-- 🛠️ **Settings Command** – Toggle maintenance mode, creeper damage, _The End_ access, sleeping‑rain, AFK time, and more
+- 🛠️ **Settings Command & GUI** – `/settings` now opens a GUI to toggle maintenance, creeper damage, enabling _The End_, sleeping‑rain, AFK time, and more
 - 🗝️ **Permissions System** – Group & user permissions with live add/remove and hot‑reload
 - 📚 **Admin Help** – Quick reference for every admin command
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ _(Scroll down for the complete feature & command list.)_
 | 🔧 `/settings` or `/set`             | List all settings with their current values          |
 | 🚧 `/settings maintenance [message]` | Toggle maintenance mode (plus optional kick message) |
 | 💥 `/settings creeperdamage`         | Toggle creeper block/entity damage                   |
-| 🏁 `/settings toggleend`             | Enable/disable entry to _The End_                    |
+| 🏁 `/settings enableend`             | Enable/disable entry to _The End_                    |
 | 🌧️ `/settings sleepingrain`          | Enable/disable sleeping to skip rain                 |
 | 💤 `/settings afktime <minutes>`     | Minutes until a player is marked AFK                 |
 

--- a/src/main/java/com/daveestar/bettervanilla/commands/SettingsCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/SettingsCommand.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import com.daveestar.bettervanilla.Main;
 import com.daveestar.bettervanilla.manager.MaintenanceManager;
 import com.daveestar.bettervanilla.manager.SettingsManager;
+import com.daveestar.bettervanilla.gui.SettingsGUI;
 
 import net.md_5.bungee.api.ChatColor;
 
@@ -20,11 +21,13 @@ public class SettingsCommand implements TabExecutor {
   private final Main _plugin;
   private final SettingsManager _settingsManager;
   private final MaintenanceManager _maintenanceManager;
+  private final SettingsGUI _settingsGUI;
 
   public SettingsCommand() {
     _plugin = Main.getInstance();
     _settingsManager = _plugin.getSettingsManager();
     _maintenanceManager = _plugin.getMaintenanceManager();
+    _settingsGUI = new SettingsGUI();
   }
 
   @Override
@@ -34,37 +37,7 @@ public class SettingsCommand implements TabExecutor {
       Player p = (Player) cs;
 
       if (args.length == 0) {
-        // list all current settings whith their values/states
-        p.sendMessage(Main.getPrefix() + ChatColor.YELLOW + ChatColor.BOLD + "SETTINGS:");
-        p.sendMessage("");
-        p.sendMessage(
-            Main.getShortPrefix() + "/settings maintenance [message] - Toggle maintenance mode and set a message");
-        p.sendMessage(ChatColor.YELLOW + "     » " + ChatColor.YELLOW + ChatColor.BOLD + "VALUE: " + ChatColor.GRAY
-            + (_settingsManager.getMaintenance() ? "ON" : "OFF"));
-        p.sendMessage(ChatColor.YELLOW + "     » " + ChatColor.YELLOW + ChatColor.BOLD + "MESSAGE: " + ChatColor.GRAY
-            + _settingsManager.getMaintenanceMessage());
-        p.sendMessage("");
-        p.sendMessage(
-            Main.getShortPrefix() + "/settings creeperdamage - Toggle creeper entity damage");
-        p.sendMessage(ChatColor.YELLOW + "     » " + ChatColor.YELLOW + ChatColor.BOLD + "VALUE: " + ChatColor.GRAY
-            + (_settingsManager.getToggleCreeperDamage() ? "ON" : "OFF"));
-        p.sendMessage("");
-        p.sendMessage(
-            Main.getShortPrefix() + "/settings toggleend - Toggle 'the end' entry");
-        p.sendMessage(ChatColor.YELLOW + "     » " + ChatColor.YELLOW + ChatColor.BOLD + "VALUE: " + ChatColor.GRAY
-            + (_settingsManager.getToggleEnd() ? "ON" : "OFF"));
-        p.sendMessage("");
-        p.sendMessage(
-            Main.getShortPrefix() + "/settings sleepingrain - Toggle sleep during rain");
-        p.sendMessage(ChatColor.YELLOW + "     » " + ChatColor.YELLOW + ChatColor.BOLD + "VALUE: " + ChatColor.GRAY
-            + (_settingsManager.getSleepingRain() ? "ON" : "OFF"));
-        p.sendMessage("");
-        p.sendMessage(
-            Main.getShortPrefix()
-                + "/settings afktime <minutes> - Set the time in minutes until a player is marked as AFK");
-        p.sendMessage(ChatColor.YELLOW + "     » " + ChatColor.YELLOW + ChatColor.BOLD + "VALUE: " + ChatColor.GRAY
-            + _settingsManager.getAFKTime() + " minutes");
-
+        _settingsGUI.displayGUI(p);
         return true;
       }
 

--- a/src/main/java/com/daveestar/bettervanilla/commands/SettingsCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/SettingsCommand.java
@@ -57,10 +57,10 @@ public class SettingsCommand implements TabExecutor {
         return true;
       }
 
-      if (args[0].equalsIgnoreCase("toggleend")) {
+      if (args[0].equalsIgnoreCase("enableend")) {
         if (args.length > 1) {
           p.sendMessage(
-              Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/settings toggleend");
+              Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/settings enableend");
           return true;
         }
 
@@ -99,7 +99,7 @@ public class SettingsCommand implements TabExecutor {
   @Override
   public List<String> onTabComplete(CommandSender cs, Command c, String label, String[] args) {
     if (args.length == 1) {
-      List<String> availableSettings = Arrays.asList("maintenance", "creeperdamage", "toggleend", "sleepingrain",
+      List<String> availableSettings = Arrays.asList("maintenance", "creeperdamage", "enableend", "sleepingrain",
           "afktime");
       return availableSettings;
     }
@@ -152,12 +152,12 @@ public class SettingsCommand implements TabExecutor {
   }
 
   private void _toggleEnd(Player p) {
-    Boolean newState = !_settingsManager.getToggleEnd();
-    String stateText = newState ? "ON" : "OFF";
+    Boolean newState = !_settingsManager.getEnableEnd();
+    String stateText = newState ? "ENABLED" : "DISABLED";
 
-    _settingsManager.setToggleEnd(newState);
+    _settingsManager.setEnableEnd(newState);
 
-    p.sendMessage(Main.getPrefix() + "The End is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+    p.sendMessage(Main.getPrefix() + "The End is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }
 
   private void _toggleSleepingRain(Player p) {

--- a/src/main/java/com/daveestar/bettervanilla/commands/SettingsCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/SettingsCommand.java
@@ -130,7 +130,7 @@ public class SettingsCommand implements TabExecutor {
 
     _maintenanceManager.setState(newState, message);
 
-    String stateText = newState ? "ON" : "OFF";
+    String stateText = newState ? "ENABLED" : "DISABLED";
 
     p.sendMessage(
         Main.getPrefix() + "The maintenance mode is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
@@ -144,7 +144,7 @@ public class SettingsCommand implements TabExecutor {
 
   private void _toggleCreeperDamage(Player p) {
     Boolean newState = !_settingsManager.getToggleCreeperDamage();
-    String stateText = newState ? "ON" : "OFF";
+    String stateText = newState ? "ENABLED" : "DISABLED";
 
     _settingsManager.setToggleCreeperDamage(newState);
 
@@ -162,7 +162,7 @@ public class SettingsCommand implements TabExecutor {
 
   private void _toggleSleepingRain(Player p) {
     Boolean newState = !_settingsManager.getSleepingRain();
-    String stateText = newState ? "ON" : "OFF";
+    String stateText = newState ? "ENABLED" : "DISABLED";
 
     _settingsManager.setSleepingRain(newState);
 

--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -5,6 +5,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerKickEvent;
 
 import com.daveestar.bettervanilla.Main;
 import com.daveestar.bettervanilla.manager.AFKManager;
@@ -66,6 +67,15 @@ public class ChatMessages implements Listener {
 
     e.quitMessage(Component
         .text(ChatColor.GRAY + "[" + ChatColor.RED + "-" + ChatColor.GRAY + "] " + ChatColor.RED + p.getName()));
+
+    _permissionsManager.onPlayerLeft(p);
+    _afkManager.onPlayerLeft(p);
+    _timerManager.onPlayerLeft(p);
+  }
+
+  @EventHandler
+  public void onPlayerKick(PlayerKickEvent e) {
+    Player p = (Player) e.getPlayer();
 
     _permissionsManager.onPlayerLeft(p);
     _afkManager.onPlayerLeft(p);

--- a/src/main/java/com/daveestar/bettervanilla/events/PreventEnd.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/PreventEnd.java
@@ -23,7 +23,7 @@ public class PreventEnd implements Listener {
 
   @EventHandler
   public void onPlayerPortal(PlayerPortalEvent event) {
-    if (_settingsManager.getToggleEnd()) {
+    if (_settingsManager.getEnableEnd()) {
       return;
     }
 

--- a/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
@@ -1,6 +1,7 @@
 package com.daveestar.bettervanilla.gui;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -121,16 +122,22 @@ public class SettingsGUI implements Listener {
 
   private ItemStack _createMaintenanceItem() {
     boolean state = _maintenanceManager.getState();
+    String message = _settingsManager.getMaintenanceMessage();
     ItemStack item = new ItemStack(Material.IRON_BARS);
     ItemMeta meta = item.getItemMeta();
     if (meta != null) {
       meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Maintenance"));
-      meta.lore(Arrays.asList(
-          "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"),
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Right-Click: Toggle with message")
-          .stream().map(Component::text).collect(Collectors.toList()));
+
+      var lore = new ArrayList<String>();
+      lore.add("");
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"));
+      if (message != null && !message.isEmpty()) {
+        lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Message: " + ChatColor.YELLOW + message);
+      }
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle");
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Right-Click: Toggle with message");
+
+      meta.lore(lore.stream().map(Component::text).collect(Collectors.toList()));
       item.setItemMeta(meta);
     }
     return item;

--- a/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
@@ -1,0 +1,264 @@
+package com.daveestar.bettervanilla.gui;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.MaintenanceManager;
+import com.daveestar.bettervanilla.manager.SettingsManager;
+import com.daveestar.bettervanilla.utils.CustomGUI;
+
+import io.papermc.paper.event.player.AsyncChatEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.md_5.bungee.api.ChatColor;
+
+public class SettingsGUI implements Listener {
+  private final Main _plugin;
+  private final SettingsManager _settingsManager;
+  private final MaintenanceManager _maintenanceManager;
+  private final Map<UUID, Boolean> _afkTimePending;
+  private final Map<UUID, Boolean> _maintenanceMessagePending;
+
+  public SettingsGUI() {
+    _plugin = Main.getInstance();
+    _settingsManager = _plugin.getSettingsManager();
+    _maintenanceManager = _plugin.getMaintenanceManager();
+    _afkTimePending = new HashMap<>();
+    _maintenanceMessagePending = new HashMap<>();
+    _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
+  }
+
+  public void displayGUI(Player p) {
+    Map<String, ItemStack> entries = new HashMap<>();
+    entries.put("maintenance", _createMaintenanceItem());
+    entries.put("creeperdamage", _createCreeperDamageItem());
+    entries.put("toggleend", _createToggleEndItem());
+    entries.put("sleepingrain", _createSleepingRainItem());
+    entries.put("afktime", _createAFKTimeItem());
+
+    Map<String, Integer> customSlots = new HashMap<>();
+    customSlots.put("maintenance", 1);
+    customSlots.put("creeperdamage", 3);
+    customSlots.put("toggleend", 5);
+    customSlots.put("sleepingrain", 7);
+    customSlots.put("afktime", 13);
+
+    CustomGUI gui = new CustomGUI(_plugin, p,
+        ChatColor.YELLOW + "" + ChatColor.BOLD + "» Settings",
+        entries, 3, customSlots, null,
+        EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
+
+    Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
+    actions.put("maintenance", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleMaintenance(player, null);
+        displayGUI(player);
+      }
+
+      @Override
+      public void onRightClick(Player player) {
+        if (!_maintenanceManager.getState()) {
+          player.sendMessage(Main.getPrefix() + "Enter maintenance message:");
+          _maintenanceMessagePending.put(player.getUniqueId(), true);
+          player.closeInventory();
+        } else {
+          _toggleMaintenance(player, null);
+          displayGUI(player);
+        }
+      }
+    });
+
+    actions.put("creeperdamage", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleCreeperDamage(player);
+        displayGUI(player);
+      }
+    });
+
+    actions.put("toggleend", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleEnd(player);
+        displayGUI(player);
+      }
+    });
+
+    actions.put("sleepingrain", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleSleepingRain(player);
+        displayGUI(player);
+      }
+    });
+
+    actions.put("afktime", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        player.sendMessage(Main.getPrefix() + "Enter AFK time in minutes:");
+        _afkTimePending.put(player.getUniqueId(), true);
+        player.closeInventory();
+      }
+    });
+
+    gui.setClickActions(actions);
+    gui.open(p);
+  }
+
+  private ItemStack _createMaintenanceItem() {
+    boolean state = _maintenanceManager.getState();
+    ItemStack item = new ItemStack(Material.IRON_BARS);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Maintenance"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Right-Click: Toggle with message")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createCreeperDamageItem() {
+    boolean state = _settingsManager.getToggleCreeperDamage();
+    ItemStack item = new ItemStack(Material.CREEPER_HEAD);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Creeper Damage"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createToggleEndItem() {
+    boolean state = _settingsManager.getToggleEnd();
+    ItemStack item = new ItemStack(Material.ENDER_EYE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Toggle End"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createSleepingRainItem() {
+    boolean state = _settingsManager.getSleepingRain();
+    ItemStack item = new ItemStack(Material.BLUE_BED);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Sleeping Rain"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createAFKTimeItem() {
+    int minutes = _settingsManager.getAFKTime();
+    ItemStack item = new ItemStack(Material.CLOCK);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "AFK Time"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + minutes + ChatColor.GRAY + " minutes",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Set value")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  @EventHandler
+  public void onPlayerChat(AsyncChatEvent e) {
+    Player p = e.getPlayer();
+    UUID id = p.getUniqueId();
+    if (_afkTimePending.containsKey(id)) {
+      e.setCancelled(true);
+      String content = ((TextComponent) e.message()).content();
+      try {
+        int minutes = Integer.parseInt(content);
+        _settingsManager.setAFKTime(minutes);
+        p.sendMessage(Main.getPrefix() + "AFK time set to: " + ChatColor.YELLOW + minutes + ChatColor.GRAY + " minutes");
+        p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
+        _afkTimePending.remove(id);
+        displayGUI(p);
+      } catch (NumberFormatException ex) {
+        p.sendMessage(Main.getPrefix() + ChatColor.RED + "Please provide a valid number.");
+      }
+      return;
+    }
+
+    if (_maintenanceMessagePending.containsKey(id)) {
+      e.setCancelled(true);
+      String message = ((TextComponent) e.message()).content();
+      _maintenanceMessagePending.remove(id);
+      _toggleMaintenance(p, message);
+      p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
+      displayGUI(p);
+    }
+  }
+
+  private void _toggleMaintenance(Player p, String message) {
+    boolean newState = !_maintenanceManager.getState();
+    _maintenanceManager.setState(newState, newState ? message : null);
+    String stateText = newState ? "ON" : "OFF";
+    p.sendMessage(Main.getPrefix() + "The maintenance mode is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+    if (newState && message != null) {
+      p.sendMessage(Main.getPrefix() + "Message was set to: " + ChatColor.YELLOW + message);
+    }
+    _maintenanceManager.kickAll(_plugin.getServer().getOnlinePlayers());
+  }
+
+  private void _toggleCreeperDamage(Player p) {
+    boolean newState = !_settingsManager.getToggleCreeperDamage();
+    _settingsManager.setToggleCreeperDamage(newState);
+    String stateText = newState ? "ON" : "OFF";
+    p.sendMessage(Main.getPrefix() + "Creeper damage is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+
+  private void _toggleEnd(Player p) {
+    boolean newState = !_settingsManager.getToggleEnd();
+    _settingsManager.setToggleEnd(newState);
+    String stateText = newState ? "ON" : "OFF";
+    p.sendMessage(Main.getPrefix() + "The End is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+
+  private void _toggleSleepingRain(Player p) {
+    boolean newState = !_settingsManager.getSleepingRain();
+    _settingsManager.setSleepingRain(newState);
+    String stateText = newState ? "ON" : "OFF";
+    p.sendMessage(Main.getPrefix() + "Sleeping Rain is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
@@ -130,7 +130,7 @@ public class SettingsGUI implements Listener {
 
       var lore = new ArrayList<String>();
       lore.add("");
-      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"));
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"));
       if (message != null && !message.isEmpty()) {
         lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Message: " + ChatColor.YELLOW + message);
       }
@@ -151,7 +151,7 @@ public class SettingsGUI implements Listener {
       meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Creeper Damage"));
       meta.lore(Arrays.asList(
           "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
           .stream().map(Component::text).collect(Collectors.toList()));
       item.setItemMeta(meta);
@@ -183,7 +183,7 @@ public class SettingsGUI implements Listener {
       meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Sleeping Rain"));
       meta.lore(Arrays.asList(
           "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
           .stream().map(Component::text).collect(Collectors.toList()));
       item.setItemMeta(meta);
@@ -244,7 +244,7 @@ public class SettingsGUI implements Listener {
   private void _toggleMaintenance(Player p, String message) {
     boolean newState = !_maintenanceManager.getState();
     _maintenanceManager.setState(newState, newState ? message : null);
-    String stateText = newState ? "ON" : "OFF";
+    String stateText = newState ? "ENABLED" : "DISABLED";
     p.sendMessage(Main.getPrefix() + "The maintenance mode is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
     if (newState && message != null) {
       p.sendMessage(Main.getPrefix() + "Message was set to: " + ChatColor.YELLOW + message);
@@ -255,7 +255,7 @@ public class SettingsGUI implements Listener {
   private void _toggleCreeperDamage(Player p) {
     boolean newState = !_settingsManager.getToggleCreeperDamage();
     _settingsManager.setToggleCreeperDamage(newState);
-    String stateText = newState ? "ON" : "OFF";
+    String stateText = newState ? "ENABLED" : "DISABLED";
     p.sendMessage(Main.getPrefix() + "Creeper damage is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }
 
@@ -269,7 +269,7 @@ public class SettingsGUI implements Listener {
   private void _toggleSleepingRain(Player p) {
     boolean newState = !_settingsManager.getSleepingRain();
     _settingsManager.setSleepingRain(newState);
-    String stateText = newState ? "ON" : "OFF";
+    String stateText = newState ? "ENABLED" : "DISABLED";
     p.sendMessage(Main.getPrefix() + "Sleeping Rain is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -61,12 +61,12 @@ public class SettingsManager {
     _config.save();
   }
 
-  public boolean getToggleEnd() {
-    return _fileConfig.getBoolean("global.toggleend", false);
+  public boolean getEnableEnd() {
+    return _fileConfig.getBoolean("global.enableend", false);
   }
 
-  public void setToggleEnd(boolean value) {
-    _fileConfig.set("global.toggleend", value);
+  public void setEnableEnd(boolean value) {
+    _fileConfig.set("global.enableend", value);
     _config.save();
   }
 


### PR DESCRIPTION
## Summary
- add SettingsGUI for toggling plugin settings
- integrate SettingsGUI with `/settings`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842f24e91748320b7dca614a14c9c4c