### PR TITLE
Enable offline player lookups for playtime

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/manager/TimerManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/TimerManager.java
@@ -97,6 +97,22 @@ public class TimerManager {
     return _playerTimers.getOrDefault(p.getUniqueId(), new PlayerTimer(0, 0)).getAFKTime();
   }
 
+  public int getPlayTime(UUID playerId) {
+    if (_playerTimers.containsKey(playerId)) {
+      return _playerTimers.get(playerId).getPlayTime();
+    }
+
+    return _loadPlayerTimer(playerId).getPlayTime();
+  }
+
+  public int getAFKTime(UUID playerId) {
+    if (_playerTimers.containsKey(playerId)) {
+      return _playerTimers.get(playerId).getAFKTime();
+    }
+
+    return _loadPlayerTimer(playerId).getAFKTime();
+  }
+
   private PlayerTimer _loadPlayerTimer(UUID playerId) {
     int playTime = _fileConfig.getInt("playerTimers." + playerId + ".playTime", 0);
     int afkTime = _fileConfig.getInt("playerTimers." + playerId + ".afkTime", 0);


### PR DESCRIPTION
## Summary
- expose playtime queries by UUID so offline players are supported
- allow `/playtime` command to read data for offline players
- tab-complete player names using both online and offline players

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fad10f6883208c65f4149efd89d5