### PR TITLE
Fix AFK entries during maintenance

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -44,13 +44,16 @@ public class ChatMessages implements Listener {
   public void onPlayerJoin(PlayerJoinEvent e) {
     Player p = (Player) e.getPlayer();
 
+    if (_maintenanceManager.getState() && !p.hasPermission("bettervanilla.maintenance.bypass")) {
+      _maintenanceManager.sendMaintenance(p);
+      return;
+    }
+
     p.playerListName(Component.text(ChatColor.RED + " » " + ChatColor.YELLOW + p.getName()));
 
     e.joinMessage(
         Component.text(
             ChatColor.GRAY + "[" + ChatColor.YELLOW + "+" + ChatColor.GRAY + "] " + ChatColor.YELLOW + p.getName()));
-
-    _maintenanceManager.sendMaintenance(p);
 
     _permissionsManager.onPlayerJoined(p);
     _afkManager.onPlayerJoined(p);


### PR DESCRIPTION
## Summary
- stop processing join routines when maintenance is active

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843005b5de883208d72a04aa56ab16e