### PR TITLE
Update docs for AFK protection and Nether toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # 📜 Changelog
 
+## [1.4.0] - 04.07.2025
+
+- **🆕 AFK Protection** – AFK players are now invulnerable, immovable and collision-free. Toggle with `/settings afkprotection` (disabled by default).
+- **🌋 Nether Toggle** – Control access to _The Nether_ via `/settings enablenether` or the settings GUI.
+- **🚀 Minecraft 1.21.7 Support** – Updated to the latest Paper build.
+- **🗑️ Cleanup** – Removed the unused maintenance config and minor formatting fixes.
+- **📚 Documentation** – README updated with new commands and features.
+
 ## [1.3.0] - 06.06.2025
 
 - **🚀 Minecraft 1.21.5 Support** – Fully ported BetterVanilla to the latest game version.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Whether you’re spinning up a fresh community project or running a seasoned net
 
 - 🧭 **Smart Navigation** – Waypoints with an intuitive GUI, a subtle bossbar compass, and live action‑bar coordinates keep everyone headed in the right direction—no external maps required.
 - 🛋️ **Seamless QoL Tweaks** – Sit on any stair, track playtime & ping, auto‑skip rainy days, and bounce back from death with instant chests. Zero learning curve—just play.
-- ⚙️ **Admin Superpowers** – One‑command maintenance mode, creeper‑damage toggles, AFK timers, and a live‑reload permission system let you craft the perfect experience in seconds.
+- ⚙️ **Admin Superpowers** – Maintenance mode, creeper‑damage toggles, AFK timers with optional protection, Nether & End access switches, and a live‑reload permission system.
 - 🔄 **Instant Recovery** – Death points & automatic death chests mean lost gear is just a quick stroll away.
 - 🌦️ **Weather? What Weather?** – Skip rain and storms by simply hopping into bed—no one likes soggy boots.
 - 🪑 **Immersive Extras** – Sittable stairs, action‑bar coordinates, and subtle HUD touches make your world feel alive.
@@ -55,7 +55,7 @@ _(Scroll down for the complete feature & command list.)_
 
 ### Admin & Server
 
-- 🛠️ **Settings Command & GUI** – `/settings` toggles maintenance, creeper damage, enabling _The End_, sleeping‑rain, AFK protection, AFK time, and more
+- 🛠️ **Settings Command & GUI** – `/settings` toggles maintenance, creeper damage, enabling _The End_ and _The Nether_, sleeping‑rain, AFK protection, AFK time, and more
 - 🗝️ **Permissions System** – Group & user permissions with live add/remove and hot‑reload
 - 📚 **Admin Help** – Quick reference for every admin command
 
@@ -142,6 +142,7 @@ _(Scroll down for the complete feature & command list.)_
 | 🚧 `/settings maintenance [message]` | Toggle maintenance mode (plus optional kick message) |
 | 💥 `/settings creeperdamage`         | Toggle creeper block/entity damage                   |
 | 🏁 `/settings enableend`             | Enable/disable entry to _The End_                    |
+| 🌋 `/settings enablenether`          | Enable/disable entry to _The Nether_                 |
 | 🌧️ `/settings sleepingrain`          | Enable/disable sleeping to skip rain                 |
 | 🛡️ `/settings afkprotection`        | Toggle AFK invulnerability & collisions              |
 | 💤 `/settings afktime <minutes>`     | Minutes until a player is marked AFK                 |


### PR DESCRIPTION
## Summary
- document Nether toggle in README and command table
- clarify admin features with AFK protection and Nether access
- add changelog entry for v1.4.0

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a6186f908320893a2d5a0c523270