### PR TITLE
Implement GUI-based settings menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+| Command       | Description              |
+| ------------- | ------------------------ |
+| 🔧 `/settings` | Open your settings menu |
 # BetterVanilla – SMP All‑in‑One 🍦✨
 
 _A lightweight, drop‑in plugin that upgrades vanilla Minecraft servers with modern quality‑of‑life features—without sacrificing the classic vibe._
@@ -55,8 +58,8 @@ _(Scroll down for the complete feature & command list.)_
 
 ### Admin & Server
 
-- 🛠️ **Settings Command & GUI** – `/settings` toggles maintenance, creeper damage, enabling _The End_ and _The Nether_, sleeping‑rain, AFK protection, AFK time, and more
-- 🛡️ **AFK Protection** – AFK players become invulnerable, immovable and collision-free (toggle via `/settings afkprotection`)
+- 🛠️ **Settings Menu** – `/settings` opens personal toggles; admins can access global server settings from there
+- 🛡️ **AFK Protection** – AFK players become invulnerable, immovable and collision-free (configurable in the settings menu)
 - 🗝️ **Permissions System** – Group & user permissions with live add/remove and hot‑reload
 - 📚 **Admin Help** – Quick reference for every admin command
 
@@ -136,17 +139,10 @@ _(Scroll down for the complete feature & command list.)_
 </details>
 
 <details><summary><strong>Settings & Maintenance 🛠️</strong></summary>
+| Command       | Description              |
+| ------------- | ------------------------ |
+| 🔧 `/settings` | Open your settings menu |
 
-| Command                              | Description                                          |
-| ------------------------------------ | ---------------------------------------------------- |
-| 🔧 `/settings` or `/set`             | List all settings with their current values          |
-| 🚧 `/settings maintenance [message]` | Toggle maintenance mode (plus optional kick message) |
-| 💥 `/settings creeperdamage`         | Toggle creeper block/entity damage                   |
-| 🏁 `/settings enableend`             | Enable/disable entry to _The End_                    |
-| 🌋 `/settings enablenether`          | Enable/disable entry to _The Nether_                 |
-| 🌧️ `/settings sleepingrain`          | Enable/disable sleeping to skip rain                 |
-| 🛡️ `/settings afkprotection`         | Toggle AFK invulnerability & collisions              |
-| 💤 `/settings afktime <minutes>`     | Minutes until a player is marked AFK                 |
 
 </details>
 
@@ -170,10 +166,12 @@ _(Scroll down for the complete feature & command list.)_
 | ➖ `/permissions user removeperm <user> <permission>`   | Remove permission from a user           |
 | 🔄 `/permissions user setgroup <user> <group>`          | Set a user's group                      |
 | 📋 `/permissions assignments`                           | List all group & user assignments       |
-| 📋 `/permissions list`                                  | List every permission assignment        |
+| 📋 `/permissions list`                                  | List all available permissions          |
 | 🔄 `/permissions reload`                                | Reload the permissions config & reapply |
 
 </details>
+
+*Use `/permissions reload` to apply permission changes without requiring players to rejoin.*
 
 <details><summary><strong>Help 📚</strong></summary>
 
@@ -199,6 +197,7 @@ bettervanilla.invsee
 bettervanilla.timer
 bettervanilla.adminhelp
 bettervanilla.settings
+bettervanilla.adminsettings
 bettervanilla.togglelocation
 bettervanilla.togglecompass
 bettervanilla.deathpoints

--- a/src/main/java/com/daveestar/bettervanilla/commands/HelpCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/HelpCommand.java
@@ -65,8 +65,6 @@ public class HelpCommand implements CommandExecutor {
       p.sendMessage("");
       p.sendMessage(Main.getShortPrefix() + "/settings <settingname> - Set and list global settings");
       p.sendMessage("");
-      p.sendMessage(Main.getShortPrefix() + ChatColor.RED + "Info: " + ChatColor.GRAY
-          + "Users need to rejoin to apply changes to their permissions");
       p.sendMessage(Main.getShortPrefix()
           + "/permissions group <addperm | removeperm> <username> <permission> - Add or remove a permission from a group");
       p.sendMessage(Main.getShortPrefix()
@@ -77,7 +75,7 @@ public class HelpCommand implements CommandExecutor {
       p.sendMessage(
           Main.getShortPrefix()
               + "/permissions assignments - List all user and group permission assignments");
-      p.sendMessage(Main.getShortPrefix() + "/permissions list - List all permissions of bettervanilla");
+      p.sendMessage(Main.getShortPrefix() + "/permissions list - List all available permissions");
       p.sendMessage(Main.getShortPrefix()
           + "/permissions reload - Reload the permissions and reapply them to all players");
 

--- a/src/main/java/com/daveestar/bettervanilla/commands/SettingsCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/SettingsCommand.java
@@ -1,231 +1,26 @@
 package com.daveestar.bettervanilla.commands;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 
-import com.daveestar.bettervanilla.Main;
-import com.daveestar.bettervanilla.manager.AFKManager;
-import com.daveestar.bettervanilla.manager.MaintenanceManager;
-import com.daveestar.bettervanilla.manager.SettingsManager;
 import com.daveestar.bettervanilla.gui.SettingsGUI;
 
-import net.md_5.bungee.api.ChatColor;
-
-public class SettingsCommand implements TabExecutor {
-
-  private final Main _plugin;
-  private final SettingsManager _settingsManager;
-  private final AFKManager _afkManager;
-  private final MaintenanceManager _maintenanceManager;
+public class SettingsCommand implements CommandExecutor {
   private final SettingsGUI _settingsGUI;
 
   public SettingsCommand() {
-    _plugin = Main.getInstance();
-    _settingsManager = _plugin.getSettingsManager();
-    _afkManager = _plugin.getAFKManager();
-    _maintenanceManager = _plugin.getMaintenanceManager();
     _settingsGUI = new SettingsGUI();
   }
 
   @Override
-  public boolean onCommand(CommandSender cs, Command c, String label, String[] args) {
+  public boolean onCommand(CommandSender cs, Command command, String label, String[] args) {
+    if (!(cs instanceof Player))
+      return false;
 
-    if (cs instanceof Player) {
-      Player p = (Player) cs;
-
-      if (args.length == 0) {
-        _settingsGUI.displayGUI(p);
-        return true;
-      }
-
-      if (args[0].equalsIgnoreCase("maintenance")) {
-        _toggleMaintenance(p, args);
-        return true;
-      }
-
-      if (args[0].equalsIgnoreCase("creeperdamage")) {
-        if (args.length > 1) {
-          p.sendMessage(
-              Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/settings creeperdamage");
-          return true;
-        }
-
-        _toggleCreeperDamage(p);
-        return true;
-      }
-
-      if (args[0].equalsIgnoreCase("enableend")) {
-        if (args.length > 1) {
-          p.sendMessage(
-              Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/settings enableend");
-          return true;
-        }
-
-        _toggleEnd(p);
-        return true;
-      }
-
-      if (args[0].equalsIgnoreCase("enablenether")) {
-        if (args.length > 1) {
-          p.sendMessage(
-              Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/settings enablenether");
-          return true;
-        }
-
-        _toggleNether(p);
-        return true;
-      }
-
-      if (args[0].equalsIgnoreCase("sleepingrain")) {
-        if (args.length > 1) {
-          p.sendMessage(
-              Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/settings sleepingrain");
-          return true;
-        }
-
-        _toggleSleepingRain(p);
-        return true;
-      }
-
-      if (args[0].equalsIgnoreCase("afkprotection")) {
-        if (args.length > 1) {
-          p.sendMessage(
-              Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/settings afkprotection");
-          return true;
-        }
-
-        _toggleAFKProtection(p);
-        return true;
-      }
-
-      if (args[0].equalsIgnoreCase("afktime")) {
-        if (args.length != 2) {
-          p.sendMessage(
-              Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/settings afktime <minutes>");
-          return true;
-        }
-
-        _setAFKTime(p, args);
-        return true;
-      }
-
-      return true;
-    }
-
-    return false;
-  }
-
-  @Override
-  public List<String> onTabComplete(CommandSender cs, Command c, String label, String[] args) {
-    if (args.length == 1) {
-      List<String> availableSettings = Arrays.asList("maintenance", "creeperdamage", "enableend", "enablenether",
-          "sleepingrain", "afkprotection", "afktime");
-      return availableSettings;
-    }
-
-    return new ArrayList<>();
-  }
-
-  private void _toggleMaintenance(Player p, String[] args) {
-    String message = null;
-
-    // check if more than one argument is passed (message)
-    if (args.length > 1) {
-      StringBuilder sb = new StringBuilder();
-
-      // concat all arguments to one string
-      for (int i = 1; i < args.length; i++) {
-        sb.append(args[i]);
-        if (i < args.length - 1) {
-          sb.append(" ");
-        }
-      }
-
-      message = sb.toString();
-    }
-
-    // set new maintenance state based on the current maintenance state
-    Boolean newState = !_maintenanceManager.getState();
-
-    _maintenanceManager.setState(newState, message);
-
-    String stateText = newState ? "ENABLED" : "DISABLED";
-
-    p.sendMessage(
-        Main.getPrefix() + "The maintenance mode is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-
-    if (newState && message != null) {
-      p.sendMessage(Main.getPrefix() + "Message was set to: " + ChatColor.YELLOW + message);
-    }
-
-    _maintenanceManager.kickAll(_plugin.getServer().getOnlinePlayers());
-  }
-
-  private void _toggleCreeperDamage(Player p) {
-    Boolean newState = !_settingsManager.getToggleCreeperDamage();
-    String stateText = newState ? "ENABLED" : "DISABLED";
-
-    _settingsManager.setToggleCreeperDamage(newState);
-
-    p.sendMessage(Main.getPrefix() + "Creeper damage is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-  }
-
-  private void _toggleEnd(Player p) {
-    Boolean newState = !_settingsManager.getEnableEnd();
-    String stateText = newState ? "ENABLED" : "DISABLED";
-
-    _settingsManager.setEnableEnd(newState);
-
-    p.sendMessage(Main.getPrefix() + "The End is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-  }
-
-  private void _toggleNether(Player p) {
-    Boolean newState = !_settingsManager.getEnableNether();
-    String stateText = newState ? "ENABLED" : "DISABLED";
-
-    _settingsManager.setEnableNether(newState);
-
-    p.sendMessage(Main.getPrefix() + "The Nether is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-  }
-
-  private void _toggleSleepingRain(Player p) {
-    Boolean newState = !_settingsManager.getSleepingRain();
-    String stateText = newState ? "ENABLED" : "DISABLED";
-
-    _settingsManager.setSleepingRain(newState);
-
-    p.sendMessage(Main.getPrefix() + "Sleeping Rain is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-  }
-
-  private void _toggleAFKProtection(Player p) {
-    Boolean newState = !_settingsManager.getAFKProtection();
-    String stateText = newState ? "ENABLED" : "DISABLED";
-
-    _settingsManager.setAFKProtection(newState);
-    _afkManager.applyProtectionToAFKPlayers(newState);
-
-    p.sendMessage(Main.getPrefix() + "AFK protection is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-  }
-
-  private void _setAFKTime(Player p, String[] args) {
-    int minutes;
-
-    try {
-      minutes = Integer.parseInt(args[1]);
-    } catch (NumberFormatException e) {
-      p.sendMessage(Main.getPrefix() + ChatColor.RED + "Please provide a valid number of minutes.");
-      return;
-    }
-
-    _settingsManager.setAFKTime(minutes);
-
-    p.sendMessage(
-        Main.getPrefix() + "AFK time was set to: " + ChatColor.YELLOW + ChatColor.BOLD + minutes + " minutes");
+    Player p = (Player) cs;
+    _settingsGUI.displayGUI(p);
+    return true;
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/commands/ToggleCompassCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/ToggleCompassCommand.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 
 import com.daveestar.bettervanilla.Main;
 import com.daveestar.bettervanilla.manager.CompassManager;
+import com.daveestar.bettervanilla.manager.SettingsManager;
 
 import net.md_5.bungee.api.ChatColor;
 
@@ -14,10 +15,12 @@ public class ToggleCompassCommand implements CommandExecutor {
 
   private final Main _plugin;
   private final CompassManager _compassManager;
+  private final SettingsManager _settingsManager;
 
   public ToggleCompassCommand() {
     _plugin = Main.getInstance();
     _compassManager = _plugin.getCompassManager();
+    _settingsManager = _plugin.getSettingsManager();
   }
 
   @Override
@@ -28,8 +31,10 @@ public class ToggleCompassCommand implements CommandExecutor {
       if (args.length == 0) {
         if (_compassManager.checkPlayerActiveCompass(p)) {
           _compassManager.removePlayerFromCompass(p);
+          _settingsManager.setToggleCompass(p, false);
         } else {
           _compassManager.addPlayerToCompass(p);
+          _settingsManager.setToggleCompass(p, true);
         }
       } else {
         p.sendMessage(Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/togglecompass");

--- a/src/main/java/com/daveestar/bettervanilla/enums/Permissions.java
+++ b/src/main/java/com/daveestar/bettervanilla/enums/Permissions.java
@@ -11,6 +11,7 @@ public enum Permissions {
   TIMER("bettervanilla.timer"),
   ADMINHELP("bettervanilla.adminhelp"),
   SETTINGS("bettervanilla.settings"),
+  ADMINSETTINGS("bettervanilla.adminsettings"),
   TOGGLELOCATION("bettervanilla.togglelocation"),
   TOGGLECOMPASS("bettervanilla.togglecompass"),
   LASTDEATH("bettervanilla.deathpoints"),

--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -12,7 +12,6 @@ import com.daveestar.bettervanilla.manager.AFKManager;
 import com.daveestar.bettervanilla.manager.CompassManager;
 import com.daveestar.bettervanilla.manager.MaintenanceManager;
 import com.daveestar.bettervanilla.manager.PermissionsManager;
-import com.daveestar.bettervanilla.manager.SettingsManager;
 import com.daveestar.bettervanilla.manager.TimerManager;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
@@ -23,7 +22,6 @@ import net.md_5.bungee.api.ChatColor;
 public class ChatMessages implements Listener {
 
   private final Main _plugin;
-  private final SettingsManager _settingsManager;
   private final PermissionsManager _permissionsManager;
   private final AFKManager _afkManager;
   private final TimerManager _timerManager;
@@ -32,7 +30,6 @@ public class ChatMessages implements Listener {
 
   public ChatMessages() {
     _plugin = Main.getInstance();
-    _settingsManager = _plugin.getSettingsManager();
     _permissionsManager = _plugin.getPermissionsManager();
     _afkManager = _plugin.getAFKManager();
     _timerManager = _plugin.getTimerManager();

--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -58,10 +58,7 @@ public class ChatMessages implements Listener {
     _permissionsManager.onPlayerJoined(p);
     _afkManager.onPlayerJoined(p);
     _timerManager.onPlayerJoined(p);
-
-    if (_settingsManager.getToggleCompass(p)) {
-      _compassManager.addPlayerToCompass(p);
-    }
+    _compassManager.onPlayerJoined(p);
   }
 
   @EventHandler
@@ -74,6 +71,7 @@ public class ChatMessages implements Listener {
     _permissionsManager.onPlayerLeft(p);
     _afkManager.onPlayerLeft(p);
     _timerManager.onPlayerLeft(p);
+    _compassManager.onPlayerLeft(p);
   }
 
   @EventHandler
@@ -83,6 +81,7 @@ public class ChatMessages implements Listener {
     _permissionsManager.onPlayerLeft(p);
     _afkManager.onPlayerLeft(p);
     _timerManager.onPlayerLeft(p);
+    _compassManager.onPlayerLeft(p);
   }
 
   @EventHandler

--- a/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
@@ -1,0 +1,365 @@
+package com.daveestar.bettervanilla.gui;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.AFKManager;
+import com.daveestar.bettervanilla.manager.MaintenanceManager;
+import com.daveestar.bettervanilla.manager.SettingsManager;
+import com.daveestar.bettervanilla.utils.CustomGUI;
+
+import io.papermc.paper.event.player.AsyncChatEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.md_5.bungee.api.ChatColor;
+
+public class AdminSettingsGUI implements Listener {
+  private final Main _plugin;
+  private final SettingsManager _settingsManager;
+  private final AFKManager _afkManager;
+  private final MaintenanceManager _maintenanceManager;
+  private final Map<UUID, CustomGUI> _afkTimePending;
+  private final Map<UUID, CustomGUI> _maintenanceMessagePending;
+
+  public AdminSettingsGUI() {
+    _plugin = Main.getInstance();
+    _settingsManager = _plugin.getSettingsManager();
+    _afkManager = _plugin.getAFKManager();
+    _maintenanceManager = _plugin.getMaintenanceManager();
+    _afkTimePending = new HashMap<>();
+    _maintenanceMessagePending = new HashMap<>();
+    _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
+  }
+
+  public void displayGUI(Player p) {
+    displayGUI(p, null);
+  }
+
+  public void displayGUI(Player p, CustomGUI parentMenu) {
+    final CustomGUI par = parentMenu;
+    Map<String, ItemStack> entries = new HashMap<>();
+    entries.put("maintenance", _createMaintenanceItem());
+    entries.put("creeperdamage", _createCreeperDamageItem());
+    entries.put("enableend", _createEnableEndItem());
+    entries.put("enablenether", _createEnableNetherItem());
+    entries.put("sleepingrain", _createSleepingRainItem());
+    entries.put("afkprotection", _createAFKProtectionItem());
+    entries.put("afktime", _createAFKTimeItem());
+
+    Map<String, Integer> customSlots = new HashMap<>();
+    // first row
+    customSlots.put("maintenance", 0);
+    customSlots.put("creeperdamage", 2);
+    customSlots.put("enableend", 4);
+    customSlots.put("enablenether", 6);
+    customSlots.put("sleepingrain", 8);
+
+    // second row
+    customSlots.put("afkprotection", 12);
+    customSlots.put("afktime", 14);
+
+    CustomGUI gui = new CustomGUI(_plugin, p,
+        ChatColor.YELLOW + "" + ChatColor.BOLD + "» Admin Settings",
+        entries, 3, customSlots, par,
+        EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
+
+
+    Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
+    actions.put("maintenance", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleMaintenance(player, null);
+        displayGUI(player, par);
+      }
+
+      @Override
+      public void onRightClick(Player player) {
+        if (!_maintenanceManager.getState()) {
+          player.sendMessage(Main.getPrefix() + "Enter maintenance message:");
+          _maintenanceMessagePending.put(player.getUniqueId(), par);
+          player.closeInventory();
+        } else {
+          _toggleMaintenance(player, null);
+          displayGUI(player, par);
+        }
+      }
+    });
+
+    actions.put("creeperdamage", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleCreeperDamage(player);
+        displayGUI(player, par);
+      }
+    });
+
+    actions.put("enableend", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleEnd(player);
+        displayGUI(player, par);
+      }
+    });
+
+    actions.put("enablenether", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleNether(player);
+        displayGUI(player, par);
+      }
+    });
+
+    actions.put("sleepingrain", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleSleepingRain(player);
+        displayGUI(player, par);
+      }
+    });
+
+    actions.put("afkprotection", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toggleAFKProtection(player);
+        displayGUI(player, par);
+      }
+    });
+
+    actions.put("afktime", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        player.sendMessage(Main.getPrefix() + "Enter AFK time in minutes:");
+        _afkTimePending.put(player.getUniqueId(), par);
+        player.closeInventory();
+      }
+    });
+
+    gui.setClickActions(actions);
+    gui.open(p);
+  }
+
+  private ItemStack _createMaintenanceItem() {
+    boolean state = _maintenanceManager.getState();
+    String message = _settingsManager.getMaintenanceMessage();
+    ItemStack item = new ItemStack(Material.IRON_BARS);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Maintenance"));
+
+      var lore = new ArrayList<String>();
+      lore.add("");
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+          + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"));
+      if (message != null && !message.isEmpty()) {
+        lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Message: " + ChatColor.YELLOW + message);
+      }
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle");
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Right-Click: Toggle with message");
+
+      meta.lore(lore.stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createCreeperDamageItem() {
+    boolean state = _settingsManager.getToggleCreeperDamage();
+    ItemStack item = new ItemStack(Material.CREEPER_HEAD);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(
+          Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Creeper Damage"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createEnableEndItem() {
+    boolean state = _settingsManager.getEnableEnd();
+    ItemStack item = new ItemStack(Material.ENDER_EYE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Enable End"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createEnableNetherItem() {
+    boolean state = _settingsManager.getEnableNether();
+    ItemStack item = new ItemStack(Material.BLAZE_ROD);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Enable Nether"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createSleepingRainItem() {
+    boolean state = _settingsManager.getSleepingRain();
+    ItemStack item = new ItemStack(Material.BLUE_BED);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Sleeping Rain"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createAFKProtectionItem() {
+    boolean state = _settingsManager.getAFKProtection();
+    ItemStack item = new ItemStack(Material.TOTEM_OF_UNDYING);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(
+          Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "AFK Protection"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createAFKTimeItem() {
+    int minutes = _settingsManager.getAFKTime();
+    ItemStack item = new ItemStack(Material.CLOCK);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "AFK Time"));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + minutes + ChatColor.GRAY
+              + " minutes",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Set value")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  @EventHandler
+  public void onPlayerChat(AsyncChatEvent e) {
+    Player p = e.getPlayer();
+    UUID id = p.getUniqueId();
+    if (_afkTimePending.containsKey(id)) {
+      e.setCancelled(true);
+      String content = ((TextComponent) e.message()).content();
+      try {
+        int minutes = Integer.parseInt(content);
+        _plugin.getServer().getScheduler().runTask(_plugin, () -> {
+          _settingsManager.setAFKTime(minutes);
+          p.sendMessage(
+              Main.getPrefix() + "AFK time set to: " + ChatColor.YELLOW + minutes + ChatColor.GRAY + " minutes");
+          p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
+          CustomGUI parMenu = _afkTimePending.remove(id);
+          displayGUI(p, parMenu);
+        });
+      } catch (NumberFormatException ex) {
+        p.sendMessage(Main.getPrefix() + ChatColor.RED + "Please provide a valid number.");
+      }
+      return;
+    }
+
+    if (_maintenanceMessagePending.containsKey(id)) {
+      e.setCancelled(true);
+      String message = ((TextComponent) e.message()).content();
+      _plugin.getServer().getScheduler().runTask(_plugin, () -> {
+        CustomGUI parMenu = _maintenanceMessagePending.remove(id);
+        _toggleMaintenance(p, message);
+        p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
+        displayGUI(p, parMenu);
+      });
+    }
+  }
+
+  private void _toggleMaintenance(Player p, String message) {
+    boolean newState = !_maintenanceManager.getState();
+    _maintenanceManager.setState(newState, newState ? message : null);
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(
+        Main.getPrefix() + "The maintenance mode is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+    if (newState && message != null) {
+      p.sendMessage(Main.getPrefix() + "Message was set to: " + ChatColor.YELLOW + message);
+    }
+    _maintenanceManager.kickAll(_plugin.getServer().getOnlinePlayers());
+  }
+
+  private void _toggleCreeperDamage(Player p) {
+    boolean newState = !_settingsManager.getToggleCreeperDamage();
+    _settingsManager.setToggleCreeperDamage(newState);
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(Main.getPrefix() + "Creeper damage is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+
+  private void _toggleEnd(Player p) {
+    boolean newState = !_settingsManager.getEnableEnd();
+    _settingsManager.setEnableEnd(newState);
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(Main.getPrefix() + "The End is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+
+  private void _toggleNether(Player p) {
+    boolean newState = !_settingsManager.getEnableNether();
+    _settingsManager.setEnableNether(newState);
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(Main.getPrefix() + "The Nether is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+
+  private void _toggleSleepingRain(Player p) {
+    boolean newState = !_settingsManager.getSleepingRain();
+    _settingsManager.setSleepingRain(newState);
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(Main.getPrefix() + "Sleeping Rain is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+
+  private void _toggleAFKProtection(Player p) {
+    boolean newState = !_settingsManager.getAFKProtection();
+    _settingsManager.setAFKProtection(newState);
+    _afkManager.applyProtectionToAFKPlayers(newState);
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(Main.getPrefix() + "AFK protection is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
@@ -1,359 +1,182 @@
 package com.daveestar.bettervanilla.gui;
 
-import java.util.Arrays;
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.bukkit.Material;
-import org.bukkit.Sound;
+import org.bukkit.block.Biome;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import com.daveestar.bettervanilla.Main;
-import com.daveestar.bettervanilla.manager.AFKManager;
-import com.daveestar.bettervanilla.manager.MaintenanceManager;
+import com.daveestar.bettervanilla.manager.CompassManager;
+import com.daveestar.bettervanilla.manager.NavigationManager;
 import com.daveestar.bettervanilla.manager.SettingsManager;
+import com.daveestar.bettervanilla.utils.ActionBar;
 import com.daveestar.bettervanilla.utils.CustomGUI;
 
-import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import net.md_5.bungee.api.ChatColor;
 
-public class SettingsGUI implements Listener {
+public class SettingsGUI {
   private final Main _plugin;
   private final SettingsManager _settingsManager;
-  private final AFKManager _afkManager;
-  private final MaintenanceManager _maintenanceManager;
-  private final Map<UUID, Boolean> _afkTimePending;
-  private final Map<UUID, Boolean> _maintenanceMessagePending;
+  private final NavigationManager _navigationManager;
+  private final CompassManager _compassManager;
+  private final ActionBar _actionBar;
+  private final AdminSettingsGUI _adminSettingsGUI;
 
   public SettingsGUI() {
     _plugin = Main.getInstance();
     _settingsManager = _plugin.getSettingsManager();
-    _afkManager = _plugin.getAFKManager();
-    _maintenanceManager = _plugin.getMaintenanceManager();
-    _afkTimePending = new HashMap<>();
-    _maintenanceMessagePending = new HashMap<>();
-    _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
+    _navigationManager = _plugin.getNavigationManager();
+    _compassManager = _plugin.getCompassManager();
+    _actionBar = _plugin.getActionBar();
+    _adminSettingsGUI = new AdminSettingsGUI();
   }
 
   public void displayGUI(Player p) {
+    boolean isAdmin = p.hasPermission("bettervanilla.adminsettings");
+    int rows = isAdmin ? 4 : 3;
+
     Map<String, ItemStack> entries = new HashMap<>();
-    entries.put("maintenance", _createMaintenanceItem());
-    entries.put("creeperdamage", _createCreeperDamageItem());
-    entries.put("enableend", _createEnableEndItem());
-    entries.put("enablenether", _createEnableNetherItem());
-    entries.put("sleepingrain", _createSleepingRainItem());
-    entries.put("afkprotection", _createAFKProtectionItem());
-    entries.put("afktime", _createAFKTimeItem());
+    entries.put("togglelocation", _createToggleLocationItem(p));
+    entries.put("togglecompass", _createToggleCompassItem(p));
+    if (isAdmin) {
+      entries.put("adminsettings", _createAdminSettingsItem());
+    }
 
     Map<String, Integer> customSlots = new HashMap<>();
-    // first row
-    customSlots.put("maintenance", 0);
-    customSlots.put("creeperdamage", 2);
-    customSlots.put("enableend", 4);
-    customSlots.put("enablenether", 6);
-    customSlots.put("sleepingrain", 8);
-
-    // second row
-    customSlots.put("afkprotection", 12);
-    customSlots.put("afktime", 14);
+    customSlots.put("togglelocation", 2);
+    customSlots.put("togglecompass", 6);
+    if (isAdmin) {
+      customSlots.put("adminsettings", rows * 9 - 10);
+    }
 
     CustomGUI gui = new CustomGUI(_plugin, p,
         ChatColor.YELLOW + "" + ChatColor.BOLD + "» Settings",
-        entries, 3, customSlots, null,
+        entries, rows, customSlots, null,
         EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
 
     Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
-    actions.put("maintenance", new CustomGUI.ClickAction() {
+    actions.put("togglelocation", new CustomGUI.ClickAction() {
       @Override
       public void onLeftClick(Player player) {
-        _toggleMaintenance(player, null);
-        displayGUI(player);
-      }
-
-      @Override
-      public void onRightClick(Player player) {
-        if (!_maintenanceManager.getState()) {
-          player.sendMessage(Main.getPrefix() + "Enter maintenance message:");
-          _maintenanceMessagePending.put(player.getUniqueId(), true);
-          player.closeInventory();
-        } else {
-          _toggleMaintenance(player, null);
-          displayGUI(player);
+        if (!player.hasPermission("bettervanilla.togglelocation")) {
+          player.playSound(player, org.bukkit.Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
+          return;
         }
-      }
-    });
-
-    actions.put("creeperdamage", new CustomGUI.ClickAction() {
-      @Override
-      public void onLeftClick(Player player) {
-        _toggleCreeperDamage(player);
+        _toggleLocation(player);
         displayGUI(player);
       }
     });
 
-    actions.put("enableend", new CustomGUI.ClickAction() {
+    actions.put("togglecompass", new CustomGUI.ClickAction() {
       @Override
       public void onLeftClick(Player player) {
-        _toggleEnd(player);
+        if (!player.hasPermission("bettervanilla.togglecompass")) {
+          player.playSound(player, org.bukkit.Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
+          return;
+        }
+        _toggleCompass(player);
         displayGUI(player);
       }
     });
 
-    actions.put("enablenether", new CustomGUI.ClickAction() {
-      @Override
-      public void onLeftClick(Player player) {
-        _toggleNether(player);
-        displayGUI(player);
-      }
-    });
-
-    actions.put("sleepingrain", new CustomGUI.ClickAction() {
-      @Override
-      public void onLeftClick(Player player) {
-        _toggleSleepingRain(player);
-        displayGUI(player);
-      }
-    });
-
-    actions.put("afkprotection", new CustomGUI.ClickAction() {
-      @Override
-      public void onLeftClick(Player player) {
-        _toggleAFKProtection(player);
-        displayGUI(player);
-      }
-    });
-
-    actions.put("afktime", new CustomGUI.ClickAction() {
-      @Override
-      public void onLeftClick(Player player) {
-        player.sendMessage(Main.getPrefix() + "Enter AFK time in minutes:");
-        _afkTimePending.put(player.getUniqueId(), true);
-        player.closeInventory();
-      }
-    });
+    if (isAdmin) {
+      actions.put("adminsettings", new CustomGUI.ClickAction() {
+        @Override
+        public void onLeftClick(Player player) {
+          _adminSettingsGUI.displayGUI(player, gui);
+        }
+      });
+    }
 
     gui.setClickActions(actions);
     gui.open(p);
   }
 
-  private ItemStack _createMaintenanceItem() {
-    boolean state = _maintenanceManager.getState();
-    String message = _settingsManager.getMaintenanceMessage();
-    ItemStack item = new ItemStack(Material.IRON_BARS);
+  private ItemStack _createToggleLocationItem(Player p) {
+    boolean state = _settingsManager.getToggleLocation(p);
+    ItemStack item = new ItemStack(Material.FILLED_MAP);
     ItemMeta meta = item.getItemMeta();
     if (meta != null) {
-      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Maintenance"));
-
-      var lore = new ArrayList<String>();
-      lore.add("");
-      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
-          + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"));
-      if (message != null && !message.isEmpty()) {
-        lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Message: " + ChatColor.YELLOW + message);
-      }
-      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle");
-      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Right-Click: Toggle with message");
-
-      meta.lore(lore.stream().map(Component::text).collect(Collectors.toList()));
-      item.setItemMeta(meta);
-    }
-    return item;
-  }
-
-  private ItemStack _createCreeperDamageItem() {
-    boolean state = _settingsManager.getToggleCreeperDamage();
-    ItemStack item = new ItemStack(Material.CREEPER_HEAD);
-    ItemMeta meta = item.getItemMeta();
-    if (meta != null) {
-      meta.displayName(
-          Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Creeper Damage"));
-      meta.lore(Arrays.asList(
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Action-Bar Location"));
+      meta.lore(java.util.Arrays.asList(
           "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
-              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
-          .stream().map(Component::text).collect(Collectors.toList()));
+          .stream().map(Component::text).toList());
       item.setItemMeta(meta);
     }
     return item;
   }
 
-  private ItemStack _createEnableEndItem() {
-    boolean state = _settingsManager.getEnableEnd();
-    ItemStack item = new ItemStack(Material.ENDER_EYE);
+  private ItemStack _createToggleCompassItem(Player p) {
+    boolean state = _compassManager.checkPlayerActiveCompass(p);
+    ItemStack item = new ItemStack(Material.COMPASS);
     ItemMeta meta = item.getItemMeta();
     if (meta != null) {
-      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Enable End"));
-      meta.lore(Arrays.asList(
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Bossbar Compass"));
+      meta.lore(java.util.Arrays.asList(
           "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
-              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
-          .stream().map(Component::text).collect(Collectors.toList()));
+          .stream().map(Component::text).toList());
       item.setItemMeta(meta);
     }
     return item;
   }
 
-  private ItemStack _createEnableNetherItem() {
-    boolean state = _settingsManager.getEnableNether();
-    ItemStack item = new ItemStack(Material.BLAZE_ROD);
+  private ItemStack _createAdminSettingsItem() {
+    ItemStack item = new ItemStack(Material.REDSTONE_TORCH);
     ItemMeta meta = item.getItemMeta();
     if (meta != null) {
-      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Enable Nether"));
-      meta.lore(Arrays.asList(
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Admin Settings"));
+      meta.lore(java.util.Arrays.asList(
           "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
-              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
-          .stream().map(Component::text).collect(Collectors.toList()));
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Open global settings")
+          .stream().map(Component::text).toList());
       item.setItemMeta(meta);
     }
     return item;
   }
 
-  private ItemStack _createSleepingRainItem() {
-    boolean state = _settingsManager.getSleepingRain();
-    ItemStack item = new ItemStack(Material.BLUE_BED);
-    ItemMeta meta = item.getItemMeta();
-    if (meta != null) {
-      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Sleeping Rain"));
-      meta.lore(Arrays.asList(
-          "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
-              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
-          .stream().map(Component::text).collect(Collectors.toList()));
-      item.setItemMeta(meta);
+  private void _toggleLocation(Player p) {
+    boolean newState;
+    if (_settingsManager.getToggleLocation(p)) {
+      _settingsManager.setToggleLocation(p, false);
+      _actionBar.removeActionBar(p);
+      newState = false;
+    } else {
+      _navigationManager.stopNavigation(p);
+      _settingsManager.setToggleLocation(p, true);
+      Biome playerBiome = p.getWorld().getBiome(p.getLocation().toBlockLocation());
+      String locationText = ChatColor.YELLOW + "X: " + ChatColor.GRAY + p.getLocation().toBlockLocation().getBlockX()
+          + ChatColor.YELLOW + " Y: " + ChatColor.GRAY + p.getLocation().toBlockLocation().getBlockY()
+          + ChatColor.YELLOW + " Z: " + ChatColor.GRAY + p.getLocation().toBlockLocation().getBlockZ() + ChatColor.RED
+          + ChatColor.BOLD + " » " + ChatColor.GRAY + playerBiome.getKey();
+      _actionBar.sendActionBar(p, locationText);
+      newState = true;
     }
-    return item;
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(Main.getPrefix() + "Action-Bar location is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }
 
-  private ItemStack _createAFKProtectionItem() {
-    boolean state = _settingsManager.getAFKProtection();
-    ItemStack item = new ItemStack(Material.TOTEM_OF_UNDYING);
-    ItemMeta meta = item.getItemMeta();
-    if (meta != null) {
-      meta.displayName(
-          Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "AFK Protection"));
-      meta.lore(Arrays.asList(
-          "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
-              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
-          .stream().map(Component::text).collect(Collectors.toList()));
-      item.setItemMeta(meta);
+  private void _toggleCompass(Player p) {
+    boolean newState;
+    if (_compassManager.checkPlayerActiveCompass(p)) {
+      _compassManager.removePlayerFromCompass(p);
+      _settingsManager.setToggleCompass(p, false);
+      newState = false;
+    } else {
+      _compassManager.addPlayerToCompass(p);
+      _settingsManager.setToggleCompass(p, true);
+      newState = true;
     }
-    return item;
-  }
-
-  private ItemStack _createAFKTimeItem() {
-    int minutes = _settingsManager.getAFKTime();
-    ItemStack item = new ItemStack(Material.CLOCK);
-    ItemMeta meta = item.getItemMeta();
-    if (meta != null) {
-      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "AFK Time"));
-      meta.lore(Arrays.asList(
-          "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + minutes + ChatColor.GRAY
-              + " minutes",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Set value")
-          .stream().map(Component::text).collect(Collectors.toList()));
-      item.setItemMeta(meta);
-    }
-    return item;
-  }
-
-  @EventHandler
-  public void onPlayerChat(AsyncChatEvent e) {
-    Player p = e.getPlayer();
-    UUID id = p.getUniqueId();
-    if (_afkTimePending.containsKey(id)) {
-      e.setCancelled(true);
-      String content = ((TextComponent) e.message()).content();
-      try {
-        int minutes = Integer.parseInt(content);
-        _plugin.getServer().getScheduler().runTask(_plugin, () -> {
-          _settingsManager.setAFKTime(minutes);
-          p.sendMessage(
-              Main.getPrefix() + "AFK time set to: " + ChatColor.YELLOW + minutes + ChatColor.GRAY + " minutes");
-          p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
-          _afkTimePending.remove(id);
-          displayGUI(p);
-        });
-      } catch (NumberFormatException ex) {
-        p.sendMessage(Main.getPrefix() + ChatColor.RED + "Please provide a valid number.");
-      }
-      return;
-    }
-
-    if (_maintenanceMessagePending.containsKey(id)) {
-      e.setCancelled(true);
-      String message = ((TextComponent) e.message()).content();
-      _plugin.getServer().getScheduler().runTask(_plugin, () -> {
-        _maintenanceMessagePending.remove(id);
-        _toggleMaintenance(p, message);
-        p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
-        displayGUI(p);
-      });
-    }
-  }
-
-  private void _toggleMaintenance(Player p, String message) {
-    boolean newState = !_maintenanceManager.getState();
-    _maintenanceManager.setState(newState, newState ? message : null);
     String stateText = newState ? "ENABLED" : "DISABLED";
-    p.sendMessage(
-        Main.getPrefix() + "The maintenance mode is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-    if (newState && message != null) {
-      p.sendMessage(Main.getPrefix() + "Message was set to: " + ChatColor.YELLOW + message);
-    }
-    _maintenanceManager.kickAll(_plugin.getServer().getOnlinePlayers());
-  }
-
-  private void _toggleCreeperDamage(Player p) {
-    boolean newState = !_settingsManager.getToggleCreeperDamage();
-    _settingsManager.setToggleCreeperDamage(newState);
-    String stateText = newState ? "ENABLED" : "DISABLED";
-    p.sendMessage(Main.getPrefix() + "Creeper damage is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-  }
-
-  private void _toggleEnd(Player p) {
-    boolean newState = !_settingsManager.getEnableEnd();
-    _settingsManager.setEnableEnd(newState);
-    String stateText = newState ? "ENABLED" : "DISABLED";
-    p.sendMessage(Main.getPrefix() + "The End is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-  }
-
-  private void _toggleNether(Player p) {
-    boolean newState = !_settingsManager.getEnableNether();
-    _settingsManager.setEnableNether(newState);
-    String stateText = newState ? "ENABLED" : "DISABLED";
-    p.sendMessage(Main.getPrefix() + "The Nether is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-  }
-
-  private void _toggleSleepingRain(Player p) {
-    boolean newState = !_settingsManager.getSleepingRain();
-    _settingsManager.setSleepingRain(newState);
-    String stateText = newState ? "ENABLED" : "DISABLED";
-    p.sendMessage(Main.getPrefix() + "Sleeping Rain is now turned: " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
-  }
-
-  private void _toggleAFKProtection(Player p) {
-    boolean newState = !_settingsManager.getAFKProtection();
-    _settingsManager.setAFKProtection(newState);
-    _afkManager.applyProtectionToAFKPlayers(newState);
-    String stateText = newState ? "ENABLED" : "DISABLED";
-    p.sendMessage(Main.getPrefix() + "AFK protection is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+    p.sendMessage(Main.getPrefix() + "Bossbar compass is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
@@ -39,7 +39,8 @@ public class SettingsGUI {
 
   public void displayGUI(Player p) {
     boolean isAdmin = p.hasPermission("bettervanilla.adminsettings");
-    int rows = isAdmin ? 4 : 3;
+    // two entry rows for admins, one for normal players (plus navigation row)
+    int rows = isAdmin ? 3 : 2;
 
     Map<String, ItemStack> entries = new HashMap<>();
     entries.put("togglelocation", _createToggleLocationItem(p));

--- a/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
@@ -66,6 +66,8 @@ public class SettingsGUI {
       @Override
       public void onLeftClick(Player player) {
         if (!player.hasPermission("bettervanilla.togglelocation")) {
+          player.sendMessage(
+              Main.getPrefix() + ChatColor.RED + "You do not have permission to toggle the Action-Bar location.");
           player.playSound(player, org.bukkit.Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
           return;
         }
@@ -78,6 +80,8 @@ public class SettingsGUI {
       @Override
       public void onLeftClick(Player player) {
         if (!player.hasPermission("bettervanilla.togglecompass")) {
+          player.sendMessage(Main.getPrefix() + ChatColor.RED
+              + "You do not have permission to toggle the Bossbar-Compass.");
           player.playSound(player, org.bukkit.Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
           return;
         }
@@ -104,10 +108,12 @@ public class SettingsGUI {
     ItemStack item = new ItemStack(Material.FILLED_MAP);
     ItemMeta meta = item.getItemMeta();
     if (meta != null) {
-      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Action-Bar Location"));
+      meta.displayName(
+          Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Action-Bar Location"));
       meta.lore(java.util.Arrays.asList(
           "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
           .stream().map(Component::text).toList());
       item.setItemMeta(meta);
@@ -120,10 +126,12 @@ public class SettingsGUI {
     ItemStack item = new ItemStack(Material.COMPASS);
     ItemMeta meta = item.getItemMeta();
     if (meta != null) {
-      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Bossbar Compass"));
+      meta.displayName(
+          Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Bossbar Compass"));
       meta.lore(java.util.Arrays.asList(
           "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
           .stream().map(Component::text).toList());
       item.setItemMeta(meta);
@@ -135,7 +143,8 @@ public class SettingsGUI {
     ItemStack item = new ItemStack(Material.REDSTONE_TORCH);
     ItemMeta meta = item.getItemMeta();
     if (meta != null) {
-      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Admin Settings"));
+      meta.displayName(
+          Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Admin Settings"));
       meta.lore(java.util.Arrays.asList(
           "",
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Open global settings")
@@ -178,6 +187,6 @@ public class SettingsGUI {
       newState = true;
     }
     String stateText = newState ? "ENABLED" : "DISABLED";
-    p.sendMessage(Main.getPrefix() + "Bossbar compass is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+    p.sendMessage(Main.getPrefix() + "Bossbar-Compass is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/CompassManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/CompassManager.java
@@ -81,7 +81,10 @@ public class CompassManager {
   }
 
   public void onPlayerLeft(Player p) {
-    removePlayerFromCompass(p);
+    BossBar bar = _activeCompass.remove(p);
+    if (bar != null) {
+      bar.removePlayer(p);
+    }
   }
 
   public void destroy() {

--- a/src/main/java/com/daveestar/bettervanilla/manager/CompassManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/CompassManager.java
@@ -74,6 +74,16 @@ public class CompassManager {
     _settingsManager = _plugin.getSettingsManager();
   }
 
+  public void onPlayerJoined(Player p) {
+    if (_settingsManager.getToggleCompass(p)) {
+      _plugin.getServer().getScheduler().runTask(_plugin, () -> addPlayerToCompass(p));
+    }
+  }
+
+  public void onPlayerLeft(Player p) {
+    removePlayerFromCompass(p);
+  }
+
   public void destroy() {
     _activeCompass.values().forEach(BossBar::removeAll);
     _activeCompass.clear();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,7 +32,7 @@ commands:
     permission: bettervanilla.adminhelp
   settings:
     aliases: [set]
-    description: List and toggle global server settings.
+    description: Open the settings menu.
     usage: /settings
     permission: bettervanilla.settings
   help:

--- a/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
+++ b/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
@@ -17,6 +17,7 @@ e:\PROJECTS\bettervanilla\src\main\java\com\daveestar\bettervanilla\events\Preve
 e:\PROJECTS\bettervanilla\src\main\java\com\daveestar\bettervanilla\commands\PingCommand.java
 e:\PROJECTS\bettervanilla\src\main\java\com\daveestar\bettervanilla\commands\WaypointsCommand.java
 e:\PROJECTS\bettervanilla\src\main\java\com\daveestar\bettervanilla\utils\ParticleBeam.java
+e:\PROJECTS\bettervanilla\src\main\java\com\daveestar\bettervanilla\gui\AdminSettingsGUI.java
 e:\PROJECTS\bettervanilla\src\main\java\com\daveestar\bettervanilla\commands\SettingsCommand.java
 e:\PROJECTS\bettervanilla\src\main\java\com\daveestar\bettervanilla\commands\ToggleCompassCommand.java
 e:\PROJECTS\bettervanilla\src\main\java\com\daveestar\bettervanilla\events\DeathChest.java


### PR DESCRIPTION
## Summary
- rename PlayerSettings classes to SettingsGUI and SettingsCommand
- drop parent menu map and capture parent via closures
- persist compass toggle state in config
- place admin settings button in its own row
- show chat feedback for personal toggles and fix double sounds
- check permissions in the player settings GUI
- restore and remove bossbar compass when players join or leave
- list every permission including Admin Settings and remove old rejoin warning

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867def6304483208914b725a4549fc5