### PR TITLE
Refactor GUI variable names and improve settings logic

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
@@ -81,70 +81,70 @@ public class AdminSettingsGUI implements Listener {
     Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
     actions.put("maintenance", new CustomGUI.ClickAction() {
       @Override
-      public void onLeftClick(Player player) {
-        _toggleMaintenance(player, null);
-        displayGUI(player, par);
+      public void onLeftClick(Player p) {
+        _toggleMaintenance(p, null);
+        displayGUI(p, par);
       }
 
       @Override
-      public void onRightClick(Player player) {
+      public void onRightClick(Player p) {
         if (!_maintenanceManager.getState()) {
-          player.sendMessage(Main.getPrefix() + "Enter maintenance message:");
-          _maintenanceMessagePending.put(player.getUniqueId(), par);
-          player.closeInventory();
+          p.sendMessage(Main.getPrefix() + "Enter maintenance message:");
+          _maintenanceMessagePending.put(p.getUniqueId(), par);
+          p.closeInventory();
         } else {
-          _toggleMaintenance(player, null);
-          displayGUI(player, par);
+          _toggleMaintenance(p, null);
+          displayGUI(p, par);
         }
       }
     });
 
     actions.put("creeperdamage", new CustomGUI.ClickAction() {
       @Override
-      public void onLeftClick(Player player) {
-        _toggleCreeperDamage(player);
-        displayGUI(player, par);
+      public void onLeftClick(Player p) {
+        _toggleCreeperDamage(p);
+        displayGUI(p, par);
       }
     });
 
     actions.put("enableend", new CustomGUI.ClickAction() {
       @Override
-      public void onLeftClick(Player player) {
-        _toggleEnd(player);
-        displayGUI(player, par);
+      public void onLeftClick(Player p) {
+        _toggleEnd(p);
+        displayGUI(p, par);
       }
     });
 
     actions.put("enablenether", new CustomGUI.ClickAction() {
       @Override
-      public void onLeftClick(Player player) {
-        _toggleNether(player);
-        displayGUI(player, par);
+      public void onLeftClick(Player p) {
+        _toggleNether(p);
+        displayGUI(p, par);
       }
     });
 
     actions.put("sleepingrain", new CustomGUI.ClickAction() {
       @Override
-      public void onLeftClick(Player player) {
-        _toggleSleepingRain(player);
-        displayGUI(player, par);
+      public void onLeftClick(Player p) {
+        _toggleSleepingRain(p);
+        displayGUI(p, par);
       }
     });
 
     actions.put("afkprotection", new CustomGUI.ClickAction() {
       @Override
-      public void onLeftClick(Player player) {
-        _toggleAFKProtection(player);
-        displayGUI(player, par);
+      public void onLeftClick(Player p) {
+        _toggleAFKProtection(p);
+        displayGUI(p, par);
       }
     });
 
     actions.put("afktime", new CustomGUI.ClickAction() {
       @Override
-      public void onLeftClick(Player player) {
-        player.sendMessage(Main.getPrefix() + "Enter AFK time in minutes:");
-        _afkTimePending.put(player.getUniqueId(), par);
-        player.closeInventory();
+      public void onLeftClick(Player p) {
+        p.sendMessage(Main.getPrefix() + "Enter AFK time in minutes:");
+        _afkTimePending.put(p.getUniqueId(), par);
+        p.closeInventory();
       }
     });
 

--- a/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
@@ -61,45 +61,45 @@ public class SettingsGUI {
         entries, rows, customSlots, null,
         EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
 
-    Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
-    actions.put("togglelocation", new CustomGUI.ClickAction() {
+    Map<String, CustomGUI.ClickAction> clickActions = new HashMap<>();
+    clickActions.put("togglelocation", new CustomGUI.ClickAction() {
       @Override
-      public void onLeftClick(Player player) {
-        if (!player.hasPermission("bettervanilla.togglelocation")) {
-          player.sendMessage(
+      public void onLeftClick(Player p) {
+        if (!p.hasPermission("bettervanilla.togglelocation")) {
+          p.sendMessage(
               Main.getPrefix() + ChatColor.RED + "You do not have permission to toggle the Action-Bar location.");
-          player.playSound(player, org.bukkit.Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
+          p.playSound(p, org.bukkit.Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
           return;
         }
-        _toggleLocation(player);
-        displayGUI(player);
+        _toggleLocation(p);
+        displayGUI(p);
       }
     });
 
-    actions.put("togglecompass", new CustomGUI.ClickAction() {
+    clickActions.put("togglecompass", new CustomGUI.ClickAction() {
       @Override
-      public void onLeftClick(Player player) {
-        if (!player.hasPermission("bettervanilla.togglecompass")) {
-          player.sendMessage(Main.getPrefix() + ChatColor.RED
+      public void onLeftClick(Player p) {
+        if (!p.hasPermission("bettervanilla.togglecompass")) {
+          p.sendMessage(Main.getPrefix() + ChatColor.RED
               + "You do not have permission to toggle the Bossbar-Compass.");
-          player.playSound(player, org.bukkit.Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
+          p.playSound(p, org.bukkit.Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
           return;
         }
-        _toggleCompass(player);
-        displayGUI(player);
+        _toggleCompass(p);
+        displayGUI(p);
       }
     });
 
     if (isAdmin) {
-      actions.put("adminsettings", new CustomGUI.ClickAction() {
+      clickActions.put("adminsettings", new CustomGUI.ClickAction() {
         @Override
-        public void onLeftClick(Player player) {
-          _adminSettingsGUI.displayGUI(player, gui);
+        public void onLeftClick(Player p) {
+          _adminSettingsGUI.displayGUI(p, gui);
         }
       });
     }
 
-    gui.setClickActions(actions);
+    gui.setClickActions(clickActions);
     gui.open(p);
   }
 
@@ -163,11 +163,13 @@ public class SettingsGUI {
     } else {
       _navigationManager.stopNavigation(p);
       _settingsManager.setToggleLocation(p, true);
-      Biome playerBiome = p.getWorld().getBiome(p.getLocation().toBlockLocation());
-      String locationText = ChatColor.YELLOW + "X: " + ChatColor.GRAY + p.getLocation().toBlockLocation().getBlockX()
-          + ChatColor.YELLOW + " Y: " + ChatColor.GRAY + p.getLocation().toBlockLocation().getBlockY()
-          + ChatColor.YELLOW + " Z: " + ChatColor.GRAY + p.getLocation().toBlockLocation().getBlockZ() + ChatColor.RED
-          + ChatColor.BOLD + " » " + ChatColor.GRAY + playerBiome.getKey();
+
+      var blockLoc = p.getLocation().toBlockLocation();
+      Biome biome = p.getWorld().getBiome(blockLoc);
+      String locationText = ChatColor.YELLOW + "X: " + ChatColor.GRAY + blockLoc.getBlockX()
+          + ChatColor.YELLOW + " Y: " + ChatColor.GRAY + blockLoc.getBlockY()
+          + ChatColor.YELLOW + " Z: " + ChatColor.GRAY + blockLoc.getBlockZ() + ChatColor.RED
+          + ChatColor.BOLD + " » " + ChatColor.GRAY + biome.getKey();
       _actionBar.sendActionBar(p, locationText);
       newState = true;
     }
@@ -176,16 +178,16 @@ public class SettingsGUI {
   }
 
   private void _toggleCompass(Player p) {
-    boolean newState;
-    if (_compassManager.checkPlayerActiveCompass(p)) {
+    boolean currentlyActive = _compassManager.checkPlayerActiveCompass(p);
+    boolean newState = !currentlyActive;
+
+    if (currentlyActive) {
       _compassManager.removePlayerFromCompass(p);
-      _settingsManager.setToggleCompass(p, false);
-      newState = false;
     } else {
       _compassManager.addPlayerToCompass(p);
-      _settingsManager.setToggleCompass(p, true);
-      newState = true;
     }
+    _settingsManager.setToggleCompass(p, newState);
+
     String stateText = newState ? "ENABLED" : "DISABLED";
     p.sendMessage(Main.getPrefix() + "Bossbar-Compass is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }

--- a/src/main/java/com/daveestar/bettervanilla/manager/CompassManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/CompassManager.java
@@ -96,12 +96,12 @@ public class CompassManager {
     return _activeCompass.containsKey(p);
   }
 
-  public void addPlayerToCompass(Player player) {
-    _activeCompass.computeIfAbsent(player, p -> {
+  public void addPlayerToCompass(Player p) {
+    _activeCompass.computeIfAbsent(p, pl -> {
       BossBar compassBossBar = Bukkit.createBossBar("", BarColor.YELLOW, BarStyle.SOLID);
-      compassBossBar.addPlayer(player);
+      compassBossBar.addPlayer(p);
 
-      _settingsManager.setToggleCompass(player, true);
+      _settingsManager.setToggleCompass(p, true);
 
       return compassBossBar;
     });
@@ -121,7 +121,7 @@ public class CompassManager {
     AsyncScheduler scheduler = _plugin.getServer().getAsyncScheduler();
 
     scheduler.runAtFixedRate(_plugin, task -> {
-      _activeCompass.forEach((player, compassBossBar) -> _updateCompassDirection(player, compassBossBar));
+      _activeCompass.forEach((pl, compassBossBar) -> _updateCompassDirection(pl, compassBossBar));
     }, 0, _UPDATE_INTERVAL, TimeUnit.MILLISECONDS);
   }
 


### PR DESCRIPTION
## Summary
- streamline SettingsGUI by renaming variables and cleaning toggle logic
- rename `player` variables to `p` in admin and settings GUIs
- adjust CompassManager API to use `p` consistently

## Testing
- `javac` compile of the project *(fails: missing Bukkit dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867f3bf80e08320b9b5897b87b9d342