### PR TITLE
Add crop trampling prevention

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -23,6 +23,7 @@ import com.daveestar.bettervanilla.events.PreventDimension;
 import com.daveestar.bettervanilla.events.ServerMOTD;
 import com.daveestar.bettervanilla.events.SittableStairs;
 import com.daveestar.bettervanilla.events.SleepingRain;
+import com.daveestar.bettervanilla.events.CropProtection;
 import com.daveestar.bettervanilla.manager.AFKManager;
 import com.daveestar.bettervanilla.manager.CompassManager;
 import com.daveestar.bettervanilla.manager.DeathPointsManager;
@@ -109,6 +110,7 @@ public class Main extends JavaPlugin {
     manager.registerEvents(new SittableStairs(), this);
     manager.registerEvents(new PreventDimension(), this);
     manager.registerEvents(new SleepingRain(), this);
+    manager.registerEvents(new CropProtection(), this);
   }
 
   @Override

--- a/src/main/java/com/daveestar/bettervanilla/events/CropProtection.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/CropProtection.java
@@ -1,0 +1,29 @@
+package com.daveestar.bettervanilla.events;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class CropProtection implements Listener {
+
+  @EventHandler(ignoreCancelled = true)
+  public void onPlayerTrample(PlayerInteractEvent e) {
+    if (e.getAction() == Action.PHYSICAL
+        && e.getClickedBlock() != null
+        && e.getClickedBlock().getType() == Material.FARMLAND
+        && e.getClickedBlock().getRelative(0, 1, 0).getType() != Material.AIR) {
+      e.setCancelled(true);
+    }
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onEntityChangeBlock(EntityChangeBlockEvent e) {
+    if (e.getBlock().getType() == Material.FARMLAND
+        && e.getBlock().getRelative(0, 1, 0).getType() != Material.AIR) {
+      e.setCancelled(true);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- keep plugin version at 1.5.0
- implement CropProtection listener
- register CropProtection in the plugin
- remove README and changelog updates from prior attempt
- ensure farmland can be trampled only when no crop is planted

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e9cb58888320b396da3d6cf95362