### PR TITLE
Add right click crop harvesting

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -23,6 +23,7 @@ import com.daveestar.bettervanilla.events.PreventDimension;
 import com.daveestar.bettervanilla.events.ServerMOTD;
 import com.daveestar.bettervanilla.events.SittableStairs;
 import com.daveestar.bettervanilla.events.SleepingRain;
+import com.daveestar.bettervanilla.events.RightClickHarvest;
 import com.daveestar.bettervanilla.manager.AFKManager;
 import com.daveestar.bettervanilla.manager.CompassManager;
 import com.daveestar.bettervanilla.manager.DeathPointsManager;
@@ -107,6 +108,7 @@ public class Main extends JavaPlugin {
     manager.registerEvents(new ChatMessages(), this);
     manager.registerEvents(new PlayerMove(), this);
     manager.registerEvents(new SittableStairs(), this);
+    manager.registerEvents(new RightClickHarvest(), this);
     manager.registerEvents(new PreventDimension(), this);
     manager.registerEvents(new SleepingRain(), this);
   }

--- a/src/main/java/com/daveestar/bettervanilla/events/RightClickHarvest.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/RightClickHarvest.java
@@ -1,0 +1,89 @@
+package com.daveestar.bettervanilla.events;
+
+import java.util.Collection;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.Ageable;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+public class RightClickHarvest implements Listener {
+
+  @EventHandler
+  public void onCropRightClick(PlayerInteractEvent e) {
+    if (e.getHand() != EquipmentSlot.HAND) {
+      return;
+    }
+
+    if (e.getAction() != Action.RIGHT_CLICK_BLOCK) {
+      return;
+    }
+
+    Block block = e.getClickedBlock();
+    if (block == null) {
+      return;
+    }
+
+    if (!(block.getBlockData() instanceof Ageable)) {
+      return;
+    }
+
+    Ageable ageable = (Ageable) block.getBlockData();
+    if (ageable.getAge() < ageable.getMaximumAge()) {
+      return;
+    }
+
+    Material seed = switch (block.getType()) {
+      case WHEAT -> Material.WHEAT_SEEDS;
+      case CARROTS -> Material.CARROT;
+      case POTATOES -> Material.POTATO;
+      case BEETROOTS -> Material.BEETROOT_SEEDS;
+      case NETHER_WART -> Material.NETHER_WART;
+      case COCOA -> Material.COCOA_BEANS;
+      default -> null;
+    };
+
+    if (seed == null) {
+      return;
+    }
+
+    e.setCancelled(true);
+    Player p = e.getPlayer();
+
+    Collection<ItemStack> drops = block.getDrops(p.getInventory().getItemInMainHand(), p);
+    boolean seedConsumed = false;
+
+    for (ItemStack drop : drops) {
+      if (!seedConsumed && drop.getType() == seed) {
+        if (drop.getAmount() > 1) {
+          drop.setAmount(drop.getAmount() - 1);
+        } else {
+          continue;
+        }
+        seedConsumed = true;
+      }
+
+      block.getWorld().dropItemNaturally(block.getLocation(), drop);
+    }
+
+    if (!seedConsumed) {
+      ItemStack seedItem = new ItemStack(seed, 1);
+      if (p.getInventory().containsAtLeast(seedItem, 1)) {
+        p.getInventory().removeItem(seedItem);
+        seedConsumed = true;
+      } else {
+        block.breakNaturally(p.getInventory().getItemInMainHand());
+        return;
+      }
+    }
+
+    ageable.setAge(0);
+    block.setBlockData(ageable);
+  }
+}


### PR DESCRIPTION
## Summary
- add RightClickHarvest listener to allow harvesting and replanting crops with a right-click
- register new event listener
- revert README changes for now

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ea090b3483209bebbab59bfd9477