### PR TITLE
Add configurable scoreboard feature

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -33,6 +33,7 @@ import com.daveestar.bettervanilla.manager.NavigationManager;
 import com.daveestar.bettervanilla.manager.PermissionsManager;
 import com.daveestar.bettervanilla.manager.SettingsManager;
 import com.daveestar.bettervanilla.manager.TimerManager;
+import com.daveestar.bettervanilla.manager.ScoreboardManager;
 import com.daveestar.bettervanilla.manager.WaypointsManager;
 import com.daveestar.bettervanilla.utils.ActionBar;
 import com.daveestar.bettervanilla.utils.Config;
@@ -50,6 +51,7 @@ public class Main extends JavaPlugin {
   private NavigationManager _navigationManager;
   private AFKManager _afkManager;
   private CompassManager _compassManager;
+  private ScoreboardManager _scoreboardManager;
 
   private SettingsManager _settingsManager;
   private PermissionsManager _permissionsManager;
@@ -78,10 +80,12 @@ public class Main extends JavaPlugin {
     _navigationManager = new NavigationManager();
     _afkManager = new AFKManager();
     _compassManager = new CompassManager();
+    _scoreboardManager = new ScoreboardManager();
 
     // initialize managers with dependencies
     _afkManager.initManagers();
     _compassManager.initManagers();
+    _scoreboardManager.initManagers();
     _maintenanceManager.initManagers();
     _navigationManager.initManagers();
     _timerManager.initManagers();
@@ -123,6 +127,7 @@ public class Main extends JavaPlugin {
     _timerManager.setRunning(false);
     getServer().getOnlinePlayers().forEach(_timerManager::onPlayerLeft);
     _compassManager.destroy();
+    _scoreboardManager.hideScoreboardForAll();
 
     _LOGGER.info("BetterVanilla - DISABLED");
   }
@@ -155,6 +160,10 @@ public class Main extends JavaPlugin {
 
   public CompassManager getCompassManager() {
     return _compassManager;
+  }
+
+  public ScoreboardManager getScoreboardManager() {
+    return _scoreboardManager;
   }
 
   public SettingsManager getSettingsManager() {

--- a/src/main/java/com/daveestar/bettervanilla/enums/ScoreboardStat.java
+++ b/src/main/java/com/daveestar/bettervanilla/enums/ScoreboardStat.java
@@ -3,14 +3,17 @@ package com.daveestar.bettervanilla.enums;
 public enum ScoreboardStat {
   PLAYTIME("Playtime"),
   AFKTIME("AFK Time"),
-  INGAMETIME("In-Game Time"),
+  INGAMETIME("Day Time"),
   PLAYERKILLS("Player Kills"),
   MOBKILLS("Mob Kills"),
   DEATHS("Deaths"),
   ONLINE("Online Players"),
-  SWIMDISTANCE("Swim Distance"),
-  WALKDISTANCE("Walk Distance"),
-  TOTALDISTANCE("Total Distance");
+  TOTALDISTANCE("Travelled"),
+  JUMPS("Jumps"),
+  ITEMSENCHANTED("Items Enchanted"),
+  FISHCAUGHT("Fish Caught"),
+  DAMAGETAKEN("Damage Taken"),
+  XPLEVEL("XP Level");
 
   private final String _displayName;
 

--- a/src/main/java/com/daveestar/bettervanilla/enums/ScoreboardStat.java
+++ b/src/main/java/com/daveestar/bettervanilla/enums/ScoreboardStat.java
@@ -1,0 +1,24 @@
+package com.daveestar.bettervanilla.enums;
+
+public enum ScoreboardStat {
+  PLAYTIME("Playtime"),
+  AFKTIME("AFK Time"),
+  INGAMETIME("In-Game Time"),
+  PLAYERKILLS("Player Kills"),
+  MOBKILLS("Mob Kills"),
+  DEATHS("Deaths"),
+  ONLINE("Online Players"),
+  SWIMDISTANCE("Swim Distance"),
+  WALKDISTANCE("Walk Distance"),
+  TOTALDISTANCE("Total Distance");
+
+  private final String _displayName;
+
+  ScoreboardStat(String displayName) {
+    _displayName = displayName;
+  }
+
+  public String getDisplayName() {
+    return _displayName;
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -13,6 +13,7 @@ import com.daveestar.bettervanilla.manager.CompassManager;
 import com.daveestar.bettervanilla.manager.MaintenanceManager;
 import com.daveestar.bettervanilla.manager.PermissionsManager;
 import com.daveestar.bettervanilla.manager.TimerManager;
+import com.daveestar.bettervanilla.manager.ScoreboardManager;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
@@ -27,6 +28,7 @@ public class ChatMessages implements Listener {
   private final TimerManager _timerManager;
   private final CompassManager _compassManager;
   private final MaintenanceManager _maintenanceManager;
+  private final ScoreboardManager _scoreboardManager;
 
   public ChatMessages() {
     _plugin = Main.getInstance();
@@ -35,6 +37,7 @@ public class ChatMessages implements Listener {
     _timerManager = _plugin.getTimerManager();
     _compassManager = _plugin.getCompassManager();
     _maintenanceManager = _plugin.getMaintenanceManager();
+    _scoreboardManager = _plugin.getScoreboardManager();
   }
 
   @EventHandler
@@ -56,6 +59,7 @@ public class ChatMessages implements Listener {
     _afkManager.onPlayerJoined(p);
     _timerManager.onPlayerJoined(p);
     _compassManager.onPlayerJoined(p);
+    _scoreboardManager.onPlayerJoined(p);
   }
 
   @EventHandler
@@ -69,6 +73,7 @@ public class ChatMessages implements Listener {
     _afkManager.onPlayerLeft(p);
     _timerManager.onPlayerLeft(p);
     _compassManager.onPlayerLeft(p);
+    _scoreboardManager.onPlayerLeft(p);
   }
 
   @EventHandler
@@ -79,6 +84,7 @@ public class ChatMessages implements Listener {
     _afkManager.onPlayerLeft(p);
     _timerManager.onPlayerLeft(p);
     _compassManager.onPlayerLeft(p);
+    _scoreboardManager.onPlayerLeft(p);
   }
 
   @EventHandler

--- a/src/main/java/com/daveestar/bettervanilla/gui/ScoreboardSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/ScoreboardSettingsGUI.java
@@ -3,9 +3,13 @@ package com.daveestar.bettervanilla.gui;
 import java.util.*;
 
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.event.Listener;
+import org.bukkit.event.EventHandler;
+import io.papermc.paper.event.player.AsyncChatEvent;
 
 import com.daveestar.bettervanilla.Main;
 import com.daveestar.bettervanilla.enums.ScoreboardStat;
@@ -15,17 +19,28 @@ import com.daveestar.bettervanilla.utils.CustomGUI;
 import net.md_5.bungee.api.ChatColor;
 import net.kyori.adventure.text.Component;
 
-public class ScoreboardSettingsGUI {
+public class ScoreboardSettingsGUI implements Listener {
   private final Main _plugin;
   private final SettingsManager _settingsManager;
+  private final com.daveestar.bettervanilla.manager.ScoreboardManager _scoreboardManager;
+
+  private final Map<java.util.UUID, ScoreboardStat> _renamePending;
+  private final Map<java.util.UUID, CustomGUI> _pendingMenu;
+  private final Map<java.util.UUID, CustomGUI> _titlePending;
 
   public ScoreboardSettingsGUI() {
     _plugin = Main.getInstance();
     _settingsManager = _plugin.getSettingsManager();
+    _scoreboardManager = _plugin.getScoreboardManager();
+    _renamePending = new java.util.HashMap<>();
+    _pendingMenu = new java.util.HashMap<>();
+    _titlePending = new java.util.HashMap<>();
+    _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
   }
 
   public void displayGUI(Player p, CustomGUI parentMenu) {
     Map<String, ItemStack> entries = new LinkedHashMap<>();
+    entries.put("title", _createTitleItem());
     for (ScoreboardStat stat : ScoreboardStat.values()) {
       entries.put(stat.name(), _createStatItem(stat));
     }
@@ -35,11 +50,40 @@ public class ScoreboardSettingsGUI {
         EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
 
     Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
+    actions.put("title", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        player.sendMessage(Main.getPrefix() + "Enter scoreboard title:");
+        _titlePending.put(player.getUniqueId(), gui);
+        player.closeInventory();
+      }
+    });
+
     for (ScoreboardStat stat : ScoreboardStat.values()) {
       actions.put(stat.name(), new CustomGUI.ClickAction() {
         @Override
         public void onLeftClick(Player player) {
           _toggleStat(stat);
+          displayGUI(player, parentMenu);
+        }
+
+        @Override
+        public void onRightClick(Player player) {
+          player.sendMessage(Main.getPrefix() + "Enter display name:");
+          _renamePending.put(player.getUniqueId(), stat);
+          _pendingMenu.put(player.getUniqueId(), gui);
+          player.closeInventory();
+        }
+
+        @Override
+        public void onShiftLeftClick(Player player) {
+          _moveStat(stat, -1);
+          displayGUI(player, parentMenu);
+        }
+
+        @Override
+        public void onShiftRightClick(Player player) {
+          _moveStat(stat, 1);
           displayGUI(player, parentMenu);
         }
       });
@@ -56,14 +100,20 @@ public class ScoreboardSettingsGUI {
     ItemMeta meta = item.getItemMeta();
 
     if (meta != null) {
-      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW
-          + stat.getDisplayName()));
-      meta.lore(Arrays.asList(
-          "",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
-              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
-          .stream().map(Component::text).toList());
+      String display = _settingsManager.getScoreboardDisplayName(stat.name());
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + display));
+
+      var lore = new ArrayList<String>();
+      lore.add("");
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+          + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"));
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle");
+      lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Right-Click: Rename");
+      if (state) {
+        lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Shift-L: Move Up");
+        lore.add(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Shift-R: Move Down");
+      }
+      meta.lore(lore.stream().map(Component::text).toList());
       item.setItemMeta(meta);
     }
 
@@ -78,5 +128,67 @@ public class ScoreboardSettingsGUI {
       enabled.add(stat.name());
     }
     _settingsManager.setScoreboardStats(enabled);
+    _scoreboardManager.showScoreboardForAll();
+  }
+
+  private ItemStack _createTitleItem() {
+    String title = _settingsManager.getScoreboardTitle();
+    ItemStack item = new ItemStack(Material.NAME_TAG);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Scoreboard Title"));
+      meta.lore(java.util.Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + title,
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Set value")
+          .stream().map(Component::text).toList());
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private void _moveStat(ScoreboardStat stat, int offset) {
+    java.util.List<String> list = new java.util.ArrayList<>(_settingsManager.getScoreboardStats());
+    int idx = list.indexOf(stat.name());
+    if (idx == -1)
+      return;
+    int newIdx = idx + offset;
+    if (newIdx < 0 || newIdx >= list.size())
+      return;
+    java.util.Collections.swap(list, idx, newIdx);
+    _settingsManager.setScoreboardStats(list);
+    _scoreboardManager.showScoreboardForAll();
+  }
+
+  @EventHandler
+  public void onChat(AsyncChatEvent e) {
+    Player p = e.getPlayer();
+    java.util.UUID id = p.getUniqueId();
+
+    if (_renamePending.containsKey(id)) {
+      e.setCancelled(true);
+      String text = ((net.kyori.adventure.text.TextComponent) e.message()).content();
+      ScoreboardStat stat = _renamePending.remove(id);
+      CustomGUI menu = _pendingMenu.remove(id);
+      _settingsManager.setScoreboardDisplayName(stat.name(), text);
+      _scoreboardManager.showScoreboardForAll();
+      _plugin.getServer().getScheduler().runTask(_plugin, () -> {
+        p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
+        displayGUI(p, menu);
+      });
+      return;
+    }
+
+    if (_titlePending.containsKey(id)) {
+      e.setCancelled(true);
+      String text = ((net.kyori.adventure.text.TextComponent) e.message()).content();
+      CustomGUI menu = _titlePending.remove(id);
+      _settingsManager.setScoreboardTitle(text);
+      _scoreboardManager.showScoreboardForAll();
+      _plugin.getServer().getScheduler().runTask(_plugin, () -> {
+        p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
+        displayGUI(p, menu);
+      });
+    }
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/gui/ScoreboardSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/ScoreboardSettingsGUI.java
@@ -1,0 +1,82 @@
+package com.daveestar.bettervanilla.gui;
+
+import java.util.*;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.enums.ScoreboardStat;
+import com.daveestar.bettervanilla.manager.SettingsManager;
+import com.daveestar.bettervanilla.utils.CustomGUI;
+
+import net.md_5.bungee.api.ChatColor;
+import net.kyori.adventure.text.Component;
+
+public class ScoreboardSettingsGUI {
+  private final Main _plugin;
+  private final SettingsManager _settingsManager;
+
+  public ScoreboardSettingsGUI() {
+    _plugin = Main.getInstance();
+    _settingsManager = _plugin.getSettingsManager();
+  }
+
+  public void displayGUI(Player p, CustomGUI parentMenu) {
+    Map<String, ItemStack> entries = new LinkedHashMap<>();
+    for (ScoreboardStat stat : ScoreboardStat.values()) {
+      entries.put(stat.name(), _createStatItem(stat));
+    }
+
+    CustomGUI gui = new CustomGUI(_plugin, p,
+        ChatColor.YELLOW + "" + ChatColor.BOLD + "» Scoreboard", entries, 3, null, parentMenu,
+        EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
+
+    Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
+    for (ScoreboardStat stat : ScoreboardStat.values()) {
+      actions.put(stat.name(), new CustomGUI.ClickAction() {
+        @Override
+        public void onLeftClick(Player player) {
+          _toggleStat(stat);
+          displayGUI(player, parentMenu);
+        }
+      });
+    }
+
+    gui.setClickActions(actions);
+    gui.open(p);
+  }
+
+  private ItemStack _createStatItem(ScoreboardStat stat) {
+    List<String> enabled = _settingsManager.getScoreboardStats();
+    boolean state = enabled.contains(stat.name());
+    ItemStack item = new ItemStack(state ? Material.LIME_WOOL : Material.RED_WOOL);
+    ItemMeta meta = item.getItemMeta();
+
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW
+          + stat.getDisplayName()));
+      meta.lore(Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).toList());
+      item.setItemMeta(meta);
+    }
+
+    return item;
+  }
+
+  private void _toggleStat(ScoreboardStat stat) {
+    List<String> enabled = new ArrayList<>(_settingsManager.getScoreboardStats());
+    if (enabled.contains(stat.name())) {
+      enabled.remove(stat.name());
+    } else {
+      enabled.add(stat.name());
+    }
+    _settingsManager.setScoreboardStats(enabled);
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/manager/ScoreboardManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/ScoreboardManager.java
@@ -82,11 +82,31 @@ public class ScoreboardManager {
         for (String entry : new ArrayList<>(board.getEntries())) {
           board.resetScores(entry);
         }
-        for (String statName : statNames) {
+
+        int score = statNames.size();
+        for (int i = 0; i < statNames.size(); i++) {
+          String statName = statNames.get(i);
+          String entry = ChatColor.values()[i].toString();
+          var team = board.getTeam("l" + i);
+          if (team == null) {
+            team = board.registerNewTeam("l" + i);
+            team.addEntry(entry);
+          }
+
           String line = _formatStat(p, statName);
           if (line != null) {
-            obj.getScore(line).setScore(0);
+            team.setPrefix(line);
+            obj.getScore(entry).setScore(score--);
           }
+        }
+
+        // remove leftover teams
+        for (int i = statNames.size(); board.getTeam("l" + i) != null; i++) {
+          var t = board.getTeam("l" + i);
+          for (String eName : t.getEntries()) {
+            board.resetScores(eName);
+          }
+          t.unregister();
         }
       }
     }, 0L, 20L);
@@ -102,38 +122,49 @@ public class ScoreboardManager {
 
     switch (stat) {
       case PLAYTIME:
-        return ChatColor.YELLOW + "Playtime: " + ChatColor.GRAY
-            + _timerManager.formatTime(_timerManager.getPlayTime(p));
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("PLAYTIME") + ": "
+            + ChatColor.GRAY + _timerManager.formatTime(_timerManager.getPlayTime(p));
       case AFKTIME:
-        return ChatColor.YELLOW + "AFK: " + ChatColor.GRAY
-            + _timerManager.formatTime(_timerManager.getAFKTime(p));
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("AFKTIME") + ": "
+            + ChatColor.GRAY + _timerManager.formatTime(_timerManager.getAFKTime(p));
       case INGAMETIME:
         long ticks = p.getWorld().getTime() % 24000;
-        return ChatColor.YELLOW + "Day: " + ChatColor.GRAY + _formatDayTime(ticks);
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("INGAMETIME") + ": "
+            + ChatColor.GRAY + _formatDayTime(ticks);
       case PLAYERKILLS:
-        return ChatColor.YELLOW + "Kills: " + ChatColor.GRAY + p.getStatistic(Statistic.PLAYER_KILLS);
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("PLAYERKILLS") + ": "
+            + ChatColor.GRAY + p.getStatistic(Statistic.PLAYER_KILLS);
       case MOBKILLS:
-        return ChatColor.YELLOW + "Mob Kills: " + ChatColor.GRAY + p.getStatistic(Statistic.MOB_KILLS);
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("MOBKILLS") + ": "
+            + ChatColor.GRAY + p.getStatistic(Statistic.MOB_KILLS);
       case DEATHS:
-        return ChatColor.YELLOW + "Deaths: " + ChatColor.GRAY + p.getStatistic(Statistic.DEATHS);
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("DEATHS") + ": "
+            + ChatColor.GRAY + p.getStatistic(Statistic.DEATHS);
       case ONLINE:
-        return ChatColor.YELLOW + "Online: " + ChatColor.GRAY + Bukkit.getOnlinePlayers().size();
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("ONLINE") + ": "
+            + ChatColor.GRAY + Bukkit.getOnlinePlayers().size();
       case TOTALDISTANCE:
         int dist = p.getStatistic(Statistic.SWIM_ONE_CM) + p.getStatistic(Statistic.WALK_ONE_CM)
             + p.getStatistic(Statistic.FLY_ONE_CM) + p.getStatistic(Statistic.HORSE_ONE_CM)
             + p.getStatistic(Statistic.MINECART_ONE_CM) + p.getStatistic(Statistic.BOAT_ONE_CM)
             + p.getStatistic(Statistic.STRIDER_ONE_CM);
-        return ChatColor.YELLOW + "Distance: " + ChatColor.GRAY + _formatDistance(dist);
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("TOTALDISTANCE") + ": "
+            + ChatColor.GRAY + _formatDistance(dist);
       case JUMPS:
-        return ChatColor.YELLOW + "Jumps: " + ChatColor.GRAY + p.getStatistic(Statistic.JUMP);
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("JUMPS") + ": "
+            + ChatColor.GRAY + p.getStatistic(Statistic.JUMP);
       case ITEMSENCHANTED:
-        return ChatColor.YELLOW + "Enchants: " + ChatColor.GRAY + p.getStatistic(Statistic.ITEM_ENCHANTED);
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("ITEMSENCHANTED") + ": "
+            + ChatColor.GRAY + p.getStatistic(Statistic.ITEM_ENCHANTED);
       case FISHCAUGHT:
-        return ChatColor.YELLOW + "Fish: " + ChatColor.GRAY + p.getStatistic(Statistic.FISH_CAUGHT);
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("FISHCAUGHT") + ": "
+            + ChatColor.GRAY + p.getStatistic(Statistic.FISH_CAUGHT);
       case DAMAGETAKEN:
-        return ChatColor.YELLOW + "Damage: " + ChatColor.GRAY + p.getStatistic(Statistic.DAMAGE_TAKEN);
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("DAMAGETAKEN") + ": "
+            + ChatColor.GRAY + p.getStatistic(Statistic.DAMAGE_TAKEN);
       case XPLEVEL:
-        return ChatColor.YELLOW + "Level: " + ChatColor.GRAY + p.getLevel();
+        return ChatColor.YELLOW + _settingsManager.getScoreboardDisplayName("XPLEVEL") + ": "
+            + ChatColor.GRAY + p.getLevel();
       default:
         return null;
     }

--- a/src/main/java/com/daveestar/bettervanilla/manager/ScoreboardManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/ScoreboardManager.java
@@ -1,0 +1,136 @@
+package com.daveestar.bettervanilla.manager;
+
+import java.util.*;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Statistic;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Criteria;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.enums.ScoreboardStat;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class ScoreboardManager {
+  private final Main _plugin;
+  private final SettingsManager _settingsManager;
+  private final TimerManager _timerManager;
+  private final Map<Player, Scoreboard> _boards;
+
+  public ScoreboardManager() {
+    _plugin = Main.getInstance();
+    _settingsManager = _plugin.getSettingsManager();
+    _timerManager = _plugin.getTimerManager();
+    _boards = new HashMap<>();
+  }
+
+  public void initManagers() {
+    _startUpdateTask();
+  }
+
+  public void onPlayerJoined(Player p) {
+    if (_settingsManager.getScoreboardEnabled()) {
+      _applyBoard(p);
+    }
+  }
+
+  public void onPlayerLeft(Player p) {
+    _boards.remove(p);
+  }
+
+  public void showScoreboardForAll() {
+    Bukkit.getOnlinePlayers().forEach(this::_applyBoard);
+  }
+
+  public void hideScoreboardForAll() {
+    Bukkit.getOnlinePlayers().forEach(p -> p.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard()));
+    _boards.clear();
+  }
+
+  private void _applyBoard(Player p) {
+    Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
+    Objective obj = board.registerNewObjective("bv_stats", Criteria.DUMMY,
+        ChatColor.YELLOW + "" + ChatColor.BOLD + "STATS");
+    obj.setDisplaySlot(DisplaySlot.SIDEBAR);
+    p.setScoreboard(board);
+    _boards.put(p, board);
+  }
+
+  private void _startUpdateTask() {
+    Bukkit.getScheduler().runTaskTimer(_plugin, () -> {
+      if (!_settingsManager.getScoreboardEnabled())
+        return;
+
+      List<String> statNames = _settingsManager.getScoreboardStats();
+      for (Player p : Bukkit.getOnlinePlayers()) {
+        Scoreboard board = _boards.computeIfAbsent(p, pl -> {
+          _applyBoard(pl);
+          return pl.getScoreboard();
+        });
+        Objective obj = board.getObjective("bv_stats");
+        if (obj == null) {
+          obj = board.registerNewObjective("bv_stats", Criteria.DUMMY,
+              ChatColor.YELLOW + "" + ChatColor.BOLD + "STATS");
+          obj.setDisplaySlot(DisplaySlot.SIDEBAR);
+        }
+        for (String entry : new ArrayList<>(board.getEntries())) {
+          board.resetScores(entry);
+        }
+        int score = statNames.size();
+        for (String statName : statNames) {
+          String line = _formatStat(p, statName);
+          if (line != null) {
+            obj.getScore(line).setScore(score--);
+          }
+        }
+      }
+    }, 0L, 20L);
+  }
+
+  private String _formatStat(Player p, String statName) {
+    ScoreboardStat stat;
+    try {
+      stat = ScoreboardStat.valueOf(statName);
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+
+    switch (stat) {
+      case PLAYTIME:
+        return ChatColor.YELLOW + "Playtime: " + ChatColor.GRAY
+            + _timerManager.formatTime(_timerManager.getPlayTime(p));
+      case AFKTIME:
+        return ChatColor.YELLOW + "AFK: " + ChatColor.GRAY
+            + _timerManager.formatTime(_timerManager.getAFKTime(p));
+      case INGAMETIME:
+        int total = _timerManager.getPlayTime(p) + _timerManager.getAFKTime(p);
+        return ChatColor.YELLOW + "Total: " + ChatColor.GRAY + _timerManager.formatTime(total);
+      case PLAYERKILLS:
+        return ChatColor.YELLOW + "Kills: " + ChatColor.GRAY + p.getStatistic(Statistic.PLAYER_KILLS);
+      case MOBKILLS:
+        return ChatColor.YELLOW + "Mob Kills: " + ChatColor.GRAY + p.getStatistic(Statistic.MOB_KILLS);
+      case DEATHS:
+        return ChatColor.YELLOW + "Deaths: " + ChatColor.GRAY + p.getStatistic(Statistic.DEATHS);
+      case ONLINE:
+        return ChatColor.YELLOW + "Online: " + ChatColor.GRAY + Bukkit.getOnlinePlayers().size();
+      case SWIMDISTANCE:
+        return ChatColor.YELLOW + "Swim: " + ChatColor.GRAY + _formatDistance(p.getStatistic(Statistic.SWIM_ONE_CM));
+      case WALKDISTANCE:
+        return ChatColor.YELLOW + "Walk: " + ChatColor.GRAY + _formatDistance(p.getStatistic(Statistic.WALK_ONE_CM));
+      case TOTALDISTANCE:
+        int dist = p.getStatistic(Statistic.SWIM_ONE_CM) + p.getStatistic(Statistic.WALK_ONE_CM);
+        return ChatColor.YELLOW + "Distance: " + ChatColor.GRAY + _formatDistance(dist);
+      default:
+        return null;
+    }
+  }
+
+  private String _formatDistance(int cm) {
+    int meters = cm / 100;
+    return meters + "m";
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/manager/ScoreboardManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/ScoreboardManager.java
@@ -54,7 +54,7 @@ public class ScoreboardManager {
   private void _applyBoard(Player p) {
     Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
     Objective obj = board.registerNewObjective("bv_stats", Criteria.DUMMY,
-        ChatColor.YELLOW + "" + ChatColor.BOLD + "STATS");
+        ChatColor.AQUA + "" + ChatColor.BOLD + _settingsManager.getScoreboardTitle());
     obj.setDisplaySlot(DisplaySlot.SIDEBAR);
     p.setScoreboard(board);
     _boards.put(p, board);
@@ -74,17 +74,18 @@ public class ScoreboardManager {
         Objective obj = board.getObjective("bv_stats");
         if (obj == null) {
           obj = board.registerNewObjective("bv_stats", Criteria.DUMMY,
-              ChatColor.YELLOW + "" + ChatColor.BOLD + "STATS");
+              ChatColor.AQUA + "" + ChatColor.BOLD + _settingsManager.getScoreboardTitle());
           obj.setDisplaySlot(DisplaySlot.SIDEBAR);
+        } else {
+          obj.setDisplayName(ChatColor.AQUA + "" + ChatColor.BOLD + _settingsManager.getScoreboardTitle());
         }
         for (String entry : new ArrayList<>(board.getEntries())) {
           board.resetScores(entry);
         }
-        int score = statNames.size();
         for (String statName : statNames) {
           String line = _formatStat(p, statName);
           if (line != null) {
-            obj.getScore(line).setScore(score--);
+            obj.getScore(line).setScore(0);
           }
         }
       }
@@ -107,8 +108,8 @@ public class ScoreboardManager {
         return ChatColor.YELLOW + "AFK: " + ChatColor.GRAY
             + _timerManager.formatTime(_timerManager.getAFKTime(p));
       case INGAMETIME:
-        int total = _timerManager.getPlayTime(p) + _timerManager.getAFKTime(p);
-        return ChatColor.YELLOW + "Total: " + ChatColor.GRAY + _timerManager.formatTime(total);
+        long ticks = p.getWorld().getTime() % 24000;
+        return ChatColor.YELLOW + "Day: " + ChatColor.GRAY + _formatDayTime(ticks);
       case PLAYERKILLS:
         return ChatColor.YELLOW + "Kills: " + ChatColor.GRAY + p.getStatistic(Statistic.PLAYER_KILLS);
       case MOBKILLS:
@@ -117,13 +118,22 @@ public class ScoreboardManager {
         return ChatColor.YELLOW + "Deaths: " + ChatColor.GRAY + p.getStatistic(Statistic.DEATHS);
       case ONLINE:
         return ChatColor.YELLOW + "Online: " + ChatColor.GRAY + Bukkit.getOnlinePlayers().size();
-      case SWIMDISTANCE:
-        return ChatColor.YELLOW + "Swim: " + ChatColor.GRAY + _formatDistance(p.getStatistic(Statistic.SWIM_ONE_CM));
-      case WALKDISTANCE:
-        return ChatColor.YELLOW + "Walk: " + ChatColor.GRAY + _formatDistance(p.getStatistic(Statistic.WALK_ONE_CM));
       case TOTALDISTANCE:
-        int dist = p.getStatistic(Statistic.SWIM_ONE_CM) + p.getStatistic(Statistic.WALK_ONE_CM);
+        int dist = p.getStatistic(Statistic.SWIM_ONE_CM) + p.getStatistic(Statistic.WALK_ONE_CM)
+            + p.getStatistic(Statistic.FLY_ONE_CM) + p.getStatistic(Statistic.HORSE_ONE_CM)
+            + p.getStatistic(Statistic.MINECART_ONE_CM) + p.getStatistic(Statistic.BOAT_ONE_CM)
+            + p.getStatistic(Statistic.STRIDER_ONE_CM);
         return ChatColor.YELLOW + "Distance: " + ChatColor.GRAY + _formatDistance(dist);
+      case JUMPS:
+        return ChatColor.YELLOW + "Jumps: " + ChatColor.GRAY + p.getStatistic(Statistic.JUMP);
+      case ITEMSENCHANTED:
+        return ChatColor.YELLOW + "Enchants: " + ChatColor.GRAY + p.getStatistic(Statistic.ITEM_ENCHANTED);
+      case FISHCAUGHT:
+        return ChatColor.YELLOW + "Fish: " + ChatColor.GRAY + p.getStatistic(Statistic.FISH_CAUGHT);
+      case DAMAGETAKEN:
+        return ChatColor.YELLOW + "Damage: " + ChatColor.GRAY + p.getStatistic(Statistic.DAMAGE_TAKEN);
+      case XPLEVEL:
+        return ChatColor.YELLOW + "Level: " + ChatColor.GRAY + p.getLevel();
       default:
         return null;
     }
@@ -132,5 +142,11 @@ public class ScoreboardManager {
   private String _formatDistance(int cm) {
     int meters = cm / 100;
     return meters + "m";
+  }
+
+  private String _formatDayTime(long ticks) {
+    int hours = (int) ((ticks / 1000 + 6) % 24);
+    int minutes = (int) (ticks % 1000 * 60 / 1000);
+    return String.format("%02d:%02d", hours, minutes);
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -132,4 +132,26 @@ public class SettingsManager {
     _fileConfig.set("global.rightclickcropharvest", value);
     _config.save();
   }
+
+  public boolean getScoreboardEnabled() {
+    return _fileConfig.getBoolean("global.scoreboard.enabled", false);
+  }
+
+  public void setScoreboardEnabled(boolean value) {
+    _fileConfig.set("global.scoreboard.enabled", value);
+    _config.save();
+  }
+
+  public java.util.List<String> getScoreboardStats() {
+    java.util.List<String> stats = _fileConfig.getStringList("global.scoreboard.stats");
+    if (stats.isEmpty()) {
+      stats = java.util.Arrays.asList("PLAYTIME", "AFKTIME", "ONLINE");
+    }
+    return stats;
+  }
+
+  public void setScoreboardStats(java.util.List<String> stats) {
+    _fileConfig.set("global.scoreboard.stats", stats);
+    _config.save();
+  }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -163,4 +163,15 @@ public class SettingsManager {
     _fileConfig.set("global.scoreboard.stats", stats);
     _config.save();
   }
+
+  public String getScoreboardDisplayName(String stat) {
+    String path = "global.scoreboard.displaynames." + stat;
+    String def = com.daveestar.bettervanilla.enums.ScoreboardStat.valueOf(stat).getDisplayName();
+    return _fileConfig.getString(path, def);
+  }
+
+  public void setScoreboardDisplayName(String stat, String name) {
+    _fileConfig.set("global.scoreboard.displaynames." + stat, name);
+    _config.save();
+  }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -142,10 +142,19 @@ public class SettingsManager {
     _config.save();
   }
 
+  public String getScoreboardTitle() {
+    return _fileConfig.getString("global.scoreboard.title", "BetterVanilla SMP");
+  }
+
+  public void setScoreboardTitle(String title) {
+    _fileConfig.set("global.scoreboard.title", title);
+    _config.save();
+  }
+
   public java.util.List<String> getScoreboardStats() {
     java.util.List<String> stats = _fileConfig.getStringList("global.scoreboard.stats");
     if (stats.isEmpty()) {
-      stats = java.util.Arrays.asList("PLAYTIME", "AFKTIME", "ONLINE");
+      stats = java.util.Arrays.asList("PLAYTIME", "AFKTIME", "ONLINE", "TOTALDISTANCE");
     }
     return stats;
   }


### PR DESCRIPTION
## Summary
- add `ScoreboardManager` to handle player scoreboards
- add `ScoreboardStat` enum for selectable statistics
- allow configuring scoreboard in `SettingsManager`
- update Admin GUI with scoreboard toggle and settings menu
- implement `ScoreboardSettingsGUI` for choosing shown stats
- wire scoreboard management into player join/leave events

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690fcb3d1c83209e2de4bd23eda076