### PR TITLE
Add waypoint particle trail option

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/SettingsGUI.java
@@ -45,6 +45,7 @@ public class SettingsGUI {
     Map<String, ItemStack> entries = new HashMap<>();
     entries.put("togglelocation", _createToggleLocationItem(p));
     entries.put("togglecompass", _createToggleCompassItem(p));
+    entries.put("navigationtrail", _createNavigationTrailItem(p));
 
     if (isAdmin) {
       entries.put("adminsettings", _createAdminSettingsItem());
@@ -53,6 +54,7 @@ public class SettingsGUI {
     Map<String, Integer> customSlots = new HashMap<>();
     customSlots.put("togglelocation", 2);
     customSlots.put("togglecompass", 6);
+    customSlots.put("navigationtrail", 4);
 
     if (isAdmin) {
       customSlots.put("adminsettings", rows * 9 - 10);
@@ -90,6 +92,14 @@ public class SettingsGUI {
         }
 
         _toggleCompass(p);
+        displayGUI(p);
+      }
+    });
+
+    clickActions.put("navigationtrail", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player p) {
+        _toggleNavigationTrail(p);
         displayGUI(p);
       }
     });
@@ -135,6 +145,26 @@ public class SettingsGUI {
     if (meta != null) {
       meta.displayName(
           Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Bossbar Compass"));
+      meta.lore(java.util.Arrays.asList(
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).toList());
+      item.setItemMeta(meta);
+    }
+
+    return item;
+  }
+
+  private ItemStack _createNavigationTrailItem(Player p) {
+    boolean state = _settingsManager.getNavigationTrail(p);
+    ItemStack item = new ItemStack(Material.BLAZE_POWDER);
+    ItemMeta meta = item.getItemMeta();
+
+    if (meta != null) {
+      meta.displayName(
+          Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Navigation Particles"));
       meta.lore(java.util.Arrays.asList(
           "",
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
@@ -204,5 +234,13 @@ public class SettingsGUI {
 
     String stateText = newState ? "ENABLED" : "DISABLED";
     p.sendMessage(Main.getPrefix() + "Bossbar-Compass is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+
+  private void _toggleNavigationTrail(Player p) {
+    boolean newState = !_settingsManager.getNavigationTrail(p);
+    _settingsManager.setNavigationTrail(p, newState);
+
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(Main.getPrefix() + "Navigation particles are now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/NavigationManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/NavigationManager.java
@@ -4,11 +4,14 @@ import com.daveestar.bettervanilla.Main;
 import com.daveestar.bettervanilla.utils.ActionBar;
 import com.daveestar.bettervanilla.utils.NavigationData;
 import com.daveestar.bettervanilla.utils.ParticleBeam;
+import com.daveestar.bettervanilla.manager.SettingsManager;
 
 import net.md_5.bungee.api.ChatColor;
 
 import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Particle.DustOptions;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
@@ -23,6 +26,7 @@ public class NavigationManager {
 
   private final Main _plugin;
   private ActionBar _actionBar;
+  private SettingsManager _settingsManager;
 
   public NavigationManager() {
     _plugin = Main.getInstance();
@@ -30,6 +34,7 @@ public class NavigationManager {
 
   public void initManagers() {
     _actionBar = _plugin.getActionBar();
+    _settingsManager = _plugin.getSettingsManager();
   }
 
   public boolean checkActiveNavigation(Player p) {
@@ -73,6 +78,8 @@ public class NavigationManager {
 
       ParticleBeam beam = _activeBeams.get(p);
       beam.updateLocation(targetLocation);
+
+      _displayNavigationTrail(p, targetLocation, navigationData.getColor());
     }
   }
 
@@ -154,6 +161,25 @@ public class NavigationManager {
       return "⬇"; // South
     } else {
       return "⬋"; // South-West
+    }
+  }
+
+  private void _displayNavigationTrail(Player p, Location targetLocation, Color color) {
+    if (!_settingsManager.getNavigationTrail(p))
+      return;
+
+    Location start = p.getLocation().clone().add(0, 1, 0);
+    double distance = start.distance(targetLocation);
+    if (distance == 0)
+      return;
+
+    double maxDistance = Math.min(distance, 10);
+    org.bukkit.util.Vector direction = targetLocation.toVector().subtract(start.toVector()).normalize();
+
+    for (double d = 0; d <= maxDistance; d += 0.5) {
+      Location point = start.clone().add(direction.clone().multiply(d));
+      DustOptions options = new DustOptions(color, 1);
+      p.spawnParticle(Particle.DUST, point, 1, 0, 0, 0, 0, options, true);
     }
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -33,6 +33,15 @@ public class SettingsManager {
     _config.save();
   }
 
+  public boolean getNavigationTrail(Player p) {
+    return _fileConfig.getBoolean(p.getUniqueId() + ".navigationtrail");
+  }
+
+  public void setNavigationTrail(Player p, boolean value) {
+    _fileConfig.set(p.getUniqueId() + ".navigationtrail", value);
+    _config.save();
+  }
+
   // GLOBAL SETTINGS
   public boolean getMaintenance() {
     return _fileConfig.getBoolean("global.maintenance.value", false);


### PR DESCRIPTION
## Summary
- let players enable navigation particle trails
- show toggle in settings GUI
- render a short particle path toward the waypoint when navigating

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686937e7dc988320b011932a2b5746fe