### PR TITLE
Add standalone backpack settings GUI

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -16,6 +16,7 @@ import com.daveestar.bettervanilla.commands.TimerCommand;
 import com.daveestar.bettervanilla.commands.ToggleCompassCommand;
 import com.daveestar.bettervanilla.commands.ToggleLocationCommand;
 import com.daveestar.bettervanilla.commands.WaypointsCommand;
+import com.daveestar.bettervanilla.commands.BackpackCommand;
 import com.daveestar.bettervanilla.events.ChatMessages;
 import com.daveestar.bettervanilla.events.DeathChest;
 import com.daveestar.bettervanilla.events.PlayerMove;
@@ -35,6 +36,7 @@ import com.daveestar.bettervanilla.manager.PermissionsManager;
 import com.daveestar.bettervanilla.manager.SettingsManager;
 import com.daveestar.bettervanilla.manager.TimerManager;
 import com.daveestar.bettervanilla.manager.WaypointsManager;
+import com.daveestar.bettervanilla.manager.BackpackManager;
 import com.daveestar.bettervanilla.utils.ActionBar;
 import com.daveestar.bettervanilla.utils.Config;
 
@@ -58,6 +60,7 @@ public class Main extends JavaPlugin {
   private WaypointsManager _waypointsManager;
   private TimerManager _timerManager;
   private MaintenanceManager _maintenanceManager;
+  private BackpackManager _backpackManager;
 
   public void onEnable() {
     _mainInstance = this;
@@ -67,12 +70,14 @@ public class Main extends JavaPlugin {
     Config timerConfig = new Config("timer.yml", getDataFolder());
     Config deathPointConfig = new Config("deathpoints.yml", getDataFolder());
     Config waypointsConfig = new Config("waypoints.yml", getDataFolder());
+    Config backpackConfig = new Config("backpacks.yml", getDataFolder());
 
     _settingsManager = new SettingsManager(settingsConfig);
     _permissionsManager = new PermissionsManager(permissionsConfig);
     _timerManager = new TimerManager(timerConfig);
     _deathPointManager = new DeathPointsManager(deathPointConfig);
     _waypointsManager = new WaypointsManager(waypointsConfig);
+    _backpackManager = new BackpackManager(backpackConfig);
 
     _maintenanceManager = new MaintenanceManager();
     _actionBar = new ActionBar();
@@ -102,6 +107,7 @@ public class Main extends JavaPlugin {
     getCommand("playtime").setExecutor(new PlayTimeCommand());
     getCommand("settings").setExecutor(new SettingsCommand());
     getCommand("permissions").setExecutor(new PermissionsCommand());
+    getCommand("backpack").setExecutor(new BackpackCommand());
 
     // register events
     PluginManager manager = getServer().getPluginManager();
@@ -181,5 +187,9 @@ public class Main extends JavaPlugin {
 
   public MaintenanceManager getMaintenanceManager() {
     return _maintenanceManager;
+  }
+
+  public BackpackManager getBackpackManager() {
+    return _backpackManager;
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -131,6 +131,7 @@ public class Main extends JavaPlugin {
     _timerManager.setRunning(false);
     getServer().getOnlinePlayers().forEach(_timerManager::onPlayerLeft);
     _compassManager.destroy();
+    _backpackManager.saveAllOpenBackpacks();
 
     _LOGGER.info("BetterVanilla - DISABLED");
   }

--- a/src/main/java/com/daveestar/bettervanilla/commands/BackpackCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/BackpackCommand.java
@@ -1,0 +1,36 @@
+package com.daveestar.bettervanilla.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.BackpackManager;
+
+public class BackpackCommand implements CommandExecutor {
+  private final BackpackManager _backpackManager;
+
+  public BackpackCommand() {
+    _backpackManager = Main.getInstance().getBackpackManager();
+  }
+
+  @Override
+  public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    if (!(sender instanceof Player)) {
+      sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+      return true;
+    }
+
+    Player p = (Player) sender;
+
+    if (args.length > 0) {
+      p.sendMessage(Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/backpack");
+      return true;
+    }
+
+    _backpackManager.openBackpack(p);
+    return true;
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
@@ -21,6 +21,7 @@ import com.daveestar.bettervanilla.manager.AFKManager;
 import com.daveestar.bettervanilla.manager.MaintenanceManager;
 import com.daveestar.bettervanilla.manager.SettingsManager;
 import com.daveestar.bettervanilla.utils.CustomGUI;
+import com.daveestar.bettervanilla.gui.BackpackSettingsGUI;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
@@ -35,6 +36,7 @@ public class AdminSettingsGUI implements Listener {
   private final Map<UUID, CustomGUI> _afkTimePending;
   private final Map<UUID, CustomGUI> _maintenanceMessagePending;
   private final Map<UUID, CustomGUI> _motdPending;
+  private final BackpackSettingsGUI _backpackSettingsGUI;
 
   public AdminSettingsGUI() {
     _plugin = Main.getInstance();
@@ -44,6 +46,7 @@ public class AdminSettingsGUI implements Listener {
     _afkTimePending = new HashMap<>();
     _maintenanceMessagePending = new HashMap<>();
     _motdPending = new HashMap<>();
+    _backpackSettingsGUI = new BackpackSettingsGUI();
     _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
   }
 
@@ -64,6 +67,7 @@ public class AdminSettingsGUI implements Listener {
     entries.put("cropprotection", _createCropProtectionItem());
     entries.put("motd", _createMOTDItem());
     entries.put("rightclickcropharvest", _createRightClickCropHarvestItem());
+    entries.put("backpacksettings", _createBackpackSettingsItem());
 
     Map<String, Integer> customSlots = new HashMap<>();
     // first row
@@ -76,6 +80,7 @@ public class AdminSettingsGUI implements Listener {
     // second row
     customSlots.put("afkprotection", 12);
     customSlots.put("afktime", 14);
+    customSlots.put("backpacksettings", 16);
 
     // third row
     customSlots.put("cropprotection", 20);
@@ -179,6 +184,13 @@ public class AdminSettingsGUI implements Listener {
         p.sendMessage(Main.getPrefix() + "Enter server MOTD:");
         _motdPending.put(p.getUniqueId(), par);
         p.closeInventory();
+      }
+    });
+
+    actions.put("backpacksettings", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player p) {
+        _backpackSettingsGUI.displayGUI(p, gui);
       }
     });
 
@@ -399,6 +411,23 @@ public class AdminSettingsGUI implements Listener {
     return item;
   }
 
+  private ItemStack _createBackpackSettingsItem() {
+    ItemStack item = new ItemStack(Material.ENDER_CHEST);
+    ItemMeta meta = item.getItemMeta();
+
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Backpack Settings"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Manage the global backpack settings.",
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Open")
+          .stream().map(Component::text).collect(Collectors.toList());
+      item.setItemMeta(meta);
+    }
+
+    return item;
+  }
+
   @EventHandler
   public void onPlayerChat(AsyncChatEvent e) {
     Player p = e.getPlayer();
@@ -457,7 +486,9 @@ public class AdminSettingsGUI implements Listener {
         p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
         displayGUI(p, parentMenu);
       });
+      return;
     }
+
   }
 
   private void _toggleMaintenance(Player p, String message) {
@@ -517,6 +548,7 @@ public class AdminSettingsGUI implements Listener {
     p.sendMessage(
         Main.getPrefix() + "Right-Click crop harvest is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }
+
 
   private void _toggleAFKProtection(Player p) {
     boolean newState = !_settingsManager.getAFKProtection();

--- a/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
@@ -421,7 +421,7 @@ public class AdminSettingsGUI implements Listener {
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Manage the global backpack settings.",
           "",
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Open")
-          .stream().map(Component::text).collect(Collectors.toList());
+          .stream().map(Component::text).collect(Collectors.toList()));
       item.setItemMeta(meta);
     }
 

--- a/src/main/java/com/daveestar/bettervanilla/gui/BackpackSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/BackpackSettingsGUI.java
@@ -1,0 +1,199 @@
+package com.daveestar.bettervanilla.gui;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.SettingsManager;
+import com.daveestar.bettervanilla.utils.CustomGUI;
+
+import io.papermc.paper.event.player.AsyncChatEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.md_5.bungee.api.ChatColor;
+
+public class BackpackSettingsGUI implements Listener {
+  private final Main _plugin;
+  private final SettingsManager _settingsManager;
+  private final Map<UUID, CustomGUI> _rowsPending;
+  private final Map<UUID, CustomGUI> _pagesPending;
+
+  public BackpackSettingsGUI() {
+    _plugin = Main.getInstance();
+    _settingsManager = _plugin.getSettingsManager();
+    _rowsPending = new HashMap<>();
+    _pagesPending = new HashMap<>();
+    _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
+  }
+
+  public void displayGUI(Player p, CustomGUI parentMenu) {
+    final CustomGUI par = parentMenu;
+    Map<String, ItemStack> entries = new HashMap<>();
+    entries.put("enabled", _createEnabledItem());
+    entries.put("rows", _createRowsItem());
+    entries.put("pages", _createPagesItem());
+
+    Map<String, Integer> customSlots = new HashMap<>();
+    customSlots.put("enabled", 10);
+    customSlots.put("rows", 13);
+    customSlots.put("pages", 16);
+
+    CustomGUI gui = new CustomGUI(_plugin, p,
+        ChatColor.YELLOW + "" + ChatColor.BOLD + "» Backpack Settings",
+        entries, 3, customSlots, par,
+        EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
+
+    Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
+    actions.put("enabled", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player pl) {
+        _toggleEnabled(pl);
+        displayGUI(pl, par);
+      }
+    });
+    actions.put("rows", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player pl) {
+        pl.sendMessage(Main.getPrefix() + "Enter backpack rows:");
+        _rowsPending.put(pl.getUniqueId(), par);
+        pl.closeInventory();
+      }
+    });
+    actions.put("pages", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player pl) {
+        pl.sendMessage(Main.getPrefix() + "Enter backpack pages:");
+        _pagesPending.put(pl.getUniqueId(), par);
+        pl.closeInventory();
+      }
+    });
+
+    gui.setClickActions(actions);
+    gui.open(p);
+  }
+
+  private ItemStack _createEnabledItem() {
+    boolean state = _settingsManager.getBackpackEnabled();
+    ItemStack item = new ItemStack(Material.ENDER_CHEST);
+    ItemMeta meta = item.getItemMeta();
+
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Backpacks"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Enable player backpacks.",
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+
+    return item;
+  }
+
+  private ItemStack _createRowsItem() {
+    int rows = _settingsManager.getBackpackRows();
+    ItemStack item = new ItemStack(Material.CHEST);
+    ItemMeta meta = item.getItemMeta();
+
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Backpack Rows"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Set number of rows per page.",
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + rows,
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Set value")
+          .stream().map(Component::text).collect(Collectors.toList());
+      item.setItemMeta(meta);
+    }
+
+    return item;
+  }
+
+  private ItemStack _createPagesItem() {
+    int pages = _settingsManager.getBackpackPages();
+    ItemStack item = new ItemStack(Material.PAPER);
+    ItemMeta meta = item.getItemMeta();
+
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Backpack Pages"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Set number of pages.",
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + pages,
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Set value")
+          .stream().map(Component::text).collect(Collectors.toList());
+      item.setItemMeta(meta);
+    }
+
+    return item;
+  }
+
+  @EventHandler
+  public void onPlayerChat(AsyncChatEvent e) {
+    Player p = e.getPlayer();
+    UUID id = p.getUniqueId();
+
+    if (_rowsPending.containsKey(id)) {
+      e.setCancelled(true);
+      String content = ((TextComponent) e.message()).content();
+
+      try {
+        int rows = Integer.parseInt(content);
+
+        _plugin.getServer().getScheduler().runTask(_plugin, () -> {
+          _settingsManager.setBackpackRows(rows);
+          _plugin.getBackpackManager().setRows(rows);
+          p.sendMessage(Main.getPrefix() + "Backpack rows set to: " + ChatColor.YELLOW + rows);
+          p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
+          CustomGUI parentMenu = _rowsPending.remove(id);
+          displayGUI(p, parentMenu);
+        });
+      } catch (NumberFormatException ex) {
+        p.sendMessage(Main.getPrefix() + ChatColor.RED + "Please provide a valid number.");
+      }
+      return;
+    }
+
+    if (_pagesPending.containsKey(id)) {
+      e.setCancelled(true);
+      String content = ((TextComponent) e.message()).content();
+
+      try {
+        int pages = Integer.parseInt(content);
+
+        _plugin.getServer().getScheduler().runTask(_plugin, () -> {
+          _settingsManager.setBackpackPages(pages);
+          _plugin.getBackpackManager().setPages(pages);
+          p.sendMessage(Main.getPrefix() + "Backpack pages set to: " + ChatColor.YELLOW + pages);
+          p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
+          CustomGUI parentMenu = _pagesPending.remove(id);
+          displayGUI(p, parentMenu);
+        });
+      } catch (NumberFormatException ex) {
+        p.sendMessage(Main.getPrefix() + ChatColor.RED + "Please provide a valid number.");
+      }
+    }
+  }
+
+  private void _toggleEnabled(Player p) {
+    boolean newState = !_settingsManager.getBackpackEnabled();
+    _settingsManager.setBackpackEnabled(newState);
+    _plugin.getBackpackManager().setEnabled(newState);
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(Main.getPrefix() + "Backpacks are now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/manager/Backpack.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/Backpack.java
@@ -1,0 +1,62 @@
+package com.daveestar.bettervanilla.manager;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemStack;
+
+import com.daveestar.bettervanilla.utils.ItemStackUtils;
+
+public class Backpack {
+  private final UUID _playerId;
+  private final Map<Integer, ItemStack[]> _pages;
+  private final int _pageSize;
+  private final int _totalPages;
+
+  public Backpack(UUID playerId, int totalPages, int pageSize, FileConfiguration cfg) {
+    _playerId = playerId;
+    _totalPages = totalPages;
+    _pageSize = pageSize;
+    _pages = new HashMap<>();
+
+    for (int i = 1; i <= totalPages; i++) {
+      _pages.put(i, _loadPage(cfg, i));
+    }
+  }
+
+  private ItemStack[] _loadPage(FileConfiguration cfg, int page) {
+    List<?> list = cfg.getList("players." + _playerId + ".page" + page);
+    ItemStack[] arr = ItemStackUtils.deserializeArray(list);
+    if (arr.length < _pageSize) {
+      ItemStack[] tmp = new ItemStack[_pageSize];
+      System.arraycopy(arr, 0, tmp, 0, arr.length);
+      return tmp;
+    }
+    return Arrays.copyOf(arr, _pageSize);
+  }
+
+  public ItemStack[] getPage(int page) {
+    return _pages.get(page);
+  }
+
+  public void setPage(int page, ItemStack[] items) {
+    if (items.length != _pageSize) {
+      items = Arrays.copyOf(items, _pageSize);
+    }
+    _pages.put(page, items);
+  }
+
+  public void savePage(FileConfiguration cfg, int page) {
+    ItemStack[] items = _pages.get(page);
+    List<Map<String, Object>> data = ItemStackUtils.serializeArray(items);
+    cfg.set("players." + _playerId + ".page" + page, data);
+  }
+
+  public int getTotalPages() {
+    return _totalPages;
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
@@ -13,12 +13,14 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.SettingsManager;
 import com.daveestar.bettervanilla.utils.Config;
 import com.daveestar.bettervanilla.utils.CustomGUI;
 import com.daveestar.bettervanilla.utils.ItemStackUtils;
 
 public class BackpackManager implements Listener {
   private final Main _plugin;
+  private final SettingsManager _settingsManager;
   private final Config _config;
   private final FileConfiguration _fileConfig;
 
@@ -30,6 +32,7 @@ public class BackpackManager implements Listener {
 
   public BackpackManager(Config config) {
     _plugin = Main.getInstance();
+    _settingsManager = _plugin.getSettingsManager();
     _config = config;
     _fileConfig = config.getFileConfig();
 
@@ -39,9 +42,9 @@ public class BackpackManager implements Listener {
   }
 
   private void _loadSettings() {
-    _enabled = _fileConfig.getBoolean("global.enabled", true);
-    _rows = _fileConfig.getInt("global.rows", 3);
-    _pages = _fileConfig.getInt("global.pages", 1);
+    _enabled = _settingsManager.getBackpackEnabled();
+    _rows = _settingsManager.getBackpackRows();
+    _pages = _settingsManager.getBackpackPages();
   }
 
   private int _getPageSize() {
@@ -54,8 +57,7 @@ public class BackpackManager implements Listener {
 
   public void setEnabled(boolean value) {
     _enabled = value;
-    _fileConfig.set("global.enabled", value);
-    _config.save();
+    _settingsManager.setBackpackEnabled(value);
   }
 
   public int getRows() {
@@ -64,8 +66,7 @@ public class BackpackManager implements Listener {
 
   public void setRows(int rows) {
     _rows = rows;
-    _fileConfig.set("global.rows", rows);
-    _config.save();
+    _settingsManager.setBackpackRows(rows);
   }
 
   public int getPages() {
@@ -74,8 +75,7 @@ public class BackpackManager implements Listener {
 
   public void setPages(int pages) {
     _pages = pages;
-    _fileConfig.set("global.pages", pages);
-    _config.save();
+    _settingsManager.setBackpackPages(pages);
   }
 
   private ItemStack[] _loadPage(UUID playerId, int page) {
@@ -153,5 +153,16 @@ public class BackpackManager implements Listener {
     if (gui != null && e.getInventory().equals(gui.getInventory())) {
       _saveCurrentPage(p, gui, gui.getCurrentPage());
     }
+  }
+
+  public void saveAllOpenBackpacks() {
+    for (Map.Entry<UUID, CustomGUI> entry : new HashMap<>(_openBackpacks).entrySet()) {
+      Player p = _plugin.getServer().getPlayer(entry.getKey());
+      if (p != null) {
+        CustomGUI gui = entry.getValue();
+        _saveCurrentPage(p, gui, gui.getCurrentPage());
+      }
+    }
+    _openBackpacks.clear();
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
@@ -1,0 +1,157 @@
+package com.daveestar.bettervanilla.manager;
+
+import java.util.*;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.utils.Config;
+import com.daveestar.bettervanilla.utils.CustomGUI;
+import com.daveestar.bettervanilla.utils.ItemStackUtils;
+
+public class BackpackManager implements Listener {
+  private final Main _plugin;
+  private final Config _config;
+  private final FileConfiguration _fileConfig;
+
+  private boolean _enabled;
+  private int _rows;
+  private int _pages;
+
+  private final Map<UUID, CustomGUI> _openBackpacks = new HashMap<>();
+
+  public BackpackManager(Config config) {
+    _plugin = Main.getInstance();
+    _config = config;
+    _fileConfig = config.getFileConfig();
+
+    _loadSettings();
+
+    Bukkit.getPluginManager().registerEvents(this, _plugin);
+  }
+
+  private void _loadSettings() {
+    _enabled = _fileConfig.getBoolean("global.enabled", true);
+    _rows = _fileConfig.getInt("global.rows", 3);
+    _pages = _fileConfig.getInt("global.pages", 1);
+  }
+
+  private int _getPageSize() {
+    return _rows * 9 - 9;
+  }
+
+  public boolean isEnabled() {
+    return _enabled;
+  }
+
+  public void setEnabled(boolean value) {
+    _enabled = value;
+    _fileConfig.set("global.enabled", value);
+    _config.save();
+  }
+
+  public int getRows() {
+    return _rows;
+  }
+
+  public void setRows(int rows) {
+    _rows = rows;
+    _fileConfig.set("global.rows", rows);
+    _config.save();
+  }
+
+  public int getPages() {
+    return _pages;
+  }
+
+  public void setPages(int pages) {
+    _pages = pages;
+    _fileConfig.set("global.pages", pages);
+    _config.save();
+  }
+
+  private ItemStack[] _loadPage(UUID playerId, int page) {
+    List<Map<?, ?>> list = _fileConfig.getMapList("players." + playerId + ".page" + page);
+    ItemStack[] arr = ItemStackUtils.deserializeArray(list);
+    int size = _getPageSize();
+    if (arr.length < size) {
+      ItemStack[] tmp = new ItemStack[size];
+      System.arraycopy(arr, 0, tmp, 0, arr.length);
+      return tmp;
+    }
+    return Arrays.copyOf(arr, size);
+  }
+
+  private void _savePage(UUID playerId, int page, ItemStack[] items) {
+    List<Map<String, Object>> data = ItemStackUtils.serializeArray(items);
+    _fileConfig.set("players." + playerId + ".page" + page, data);
+    _config.save();
+  }
+
+  public void openBackpack(Player p) {
+    if (!_enabled) {
+      p.sendMessage(Main.getPrefix() + ChatColor.RED + "Backpacks are disabled.");
+      return;
+    }
+
+    int pageSize = _getPageSize();
+
+    Map<String, ItemStack> entries = new LinkedHashMap<>();
+    Map<String, Integer> customSlots = new HashMap<>();
+
+    for (int page = 1; page <= _pages; page++) {
+      ItemStack[] items = _loadPage(p.getUniqueId(), page);
+      for (int i = 0; i < pageSize; i++) {
+        String key = page + "_" + i;
+        ItemStack item = items[i];
+        entries.put(key, item);
+        customSlots.put(key, i);
+      }
+    }
+
+    CustomGUI gui = new CustomGUI(_plugin, p,
+        ChatColor.YELLOW + "" + ChatColor.BOLD + "» Backpack",
+        entries, _rows, customSlots, null,
+        EnumSet.of(CustomGUI.Option.ALLOW_ITEM_MOVEMENT));
+
+    gui.setClickActions(new HashMap<>());
+    gui.setPageSwitchListener((pl, newPage, oldPage) -> {
+      _saveCurrentPage(pl, gui, oldPage);
+    });
+
+    gui.open(p);
+    _openBackpacks.put(p.getUniqueId(), gui);
+  }
+
+  private void _saveCurrentPage(Player p, CustomGUI gui, int page) {
+    int pageSize = _getPageSize();
+    ItemStack[] items = new ItemStack[pageSize];
+    Inventory inv = gui.getInventory();
+    for (Map.Entry<Integer, String> entry : gui.getSlotKeyMap().entrySet()) {
+      String key = entry.getValue();
+      String[] parts = key.split("_");
+      if (parts.length != 2)
+        continue;
+      int slotIndex = Integer.parseInt(parts[1]);
+      items[slotIndex] = inv.getItem(entry.getKey());
+    }
+    _savePage(p.getUniqueId(), page, items);
+  }
+
+  @EventHandler
+  public void onInventoryClose(InventoryCloseEvent e) {
+    Player p = (Player) e.getPlayer();
+    CustomGUI gui = _openBackpacks.remove(p.getUniqueId());
+    if (gui != null && e.getInventory().equals(gui.getInventory())) {
+      _saveCurrentPage(p, gui, gui.getCurrentPage());
+    }
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
@@ -120,7 +120,7 @@ public class BackpackManager implements Listener {
     CustomGUI gui = new CustomGUI(_plugin, p,
         ChatColor.YELLOW + "" + ChatColor.BOLD + "» Backpack",
         entries, _rows, customSlots, null,
-        EnumSet.of(CustomGUI.Option.ALLOW_ITEM_MOVEMENT));
+        EnumSet.noneOf(CustomGUI.Option.class));
 
     gui.setClickActions(new HashMap<>());
     gui.setPageSwitchListener((pl, newPage, oldPage) -> {
@@ -141,7 +141,9 @@ public class BackpackManager implements Listener {
       if (parts.length != 2)
         continue;
       int slotIndex = Integer.parseInt(parts[1]);
-      items[slotIndex] = inv.getItem(entry.getKey());
+      ItemStack it = inv.getItem(entry.getKey());
+      items[slotIndex] = it;
+      gui.setEntryItem(key, it);
     }
     _savePage(p.getUniqueId(), page, items);
   }

--- a/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
@@ -120,7 +120,7 @@ public class BackpackManager implements Listener {
     CustomGUI gui = new CustomGUI(_plugin, p,
         ChatColor.YELLOW + "" + ChatColor.BOLD + "» Backpack",
         entries, _rows, customSlots, null,
-        EnumSet.noneOf(CustomGUI.Option.class));
+        EnumSet.of(CustomGUI.Option.ALLOW_ITEM_MOVEMENT));
 
     gui.setClickActions(new HashMap<>());
     gui.setPageSwitchListener((pl, newPage, oldPage) -> {
@@ -135,14 +135,10 @@ public class BackpackManager implements Listener {
     int pageSize = _getPageSize();
     ItemStack[] items = new ItemStack[pageSize];
     Inventory inv = gui.getInventory();
-    for (Map.Entry<Integer, String> entry : gui.getSlotKeyMap().entrySet()) {
-      String key = entry.getValue();
-      String[] parts = key.split("_");
-      if (parts.length != 2)
-        continue;
-      int slotIndex = Integer.parseInt(parts[1]);
-      ItemStack it = inv.getItem(entry.getKey());
-      items[slotIndex] = it;
+    for (int i = 0; i < pageSize; i++) {
+      ItemStack it = inv.getItem(i);
+      items[i] = it;
+      String key = page + "_" + i;
       gui.setEntryItem(key, it);
     }
     _savePage(p.getUniqueId(), page, items);

--- a/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/BackpackManager.java
@@ -79,7 +79,7 @@ public class BackpackManager implements Listener {
   }
 
   private ItemStack[] _loadPage(UUID playerId, int page) {
-    List<Map<?, ?>> list = _fileConfig.getMapList("players." + playerId + ".page" + page);
+    List<?> list = _fileConfig.getList("players." + playerId + ".page" + page);
     ItemStack[] arr = ItemStackUtils.deserializeArray(list);
     int size = _getPageSize();
     if (arr.length < size) {

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -150,4 +150,31 @@ public class SettingsManager {
     _fileConfig.set("global.rightclickcropharvest", value);
     _config.save();
   }
+
+  public boolean getBackpackEnabled() {
+    return _fileConfig.getBoolean("global.backpack.enabled", true);
+  }
+
+  public void setBackpackEnabled(boolean value) {
+    _fileConfig.set("global.backpack.enabled", value);
+    _config.save();
+  }
+
+  public int getBackpackRows() {
+    return _fileConfig.getInt("global.backpack.rows", 3);
+  }
+
+  public void setBackpackRows(int value) {
+    _fileConfig.set("global.backpack.rows", value);
+    _config.save();
+  }
+
+  public int getBackpackPages() {
+    return _fileConfig.getInt("global.backpack.pages", 1);
+  }
+
+  public void setBackpackPages(int value) {
+    _fileConfig.set("global.backpack.pages", value);
+    _config.save();
+  }
 }

--- a/src/main/java/com/daveestar/bettervanilla/utils/CustomGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/utils/CustomGUI.java
@@ -198,7 +198,8 @@ public class CustomGUI implements Listener {
 
     e.setCancelled(true);
 
-    if (!allowMove && isItemSlot && e.getCursor().getType() == Material.AIR) {
+    if (allowMove && isItemSlot && e.getCursor().getType() == Material.AIR
+        && !isNavSlot && !isActionSlot) {
       ItemStack item = _gui.getItem(rawSlot);
       if (item != null) {
         if (e.isShiftClick()) {

--- a/src/main/java/com/daveestar/bettervanilla/utils/CustomGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/utils/CustomGUI.java
@@ -180,8 +180,11 @@ public class CustomGUI implements Listener {
     int rawSlot = e.getRawSlot();
     int topSize = _gui.getSize();
 
-    if (rawSlot >= topSize)
+    if (rawSlot >= topSize) {
+      if (!allowMove)
+        e.setCancelled(true);
       return; // player inventory interaction
+    }
 
     boolean isNavSlot = rawSlot >= topSize - _INVENTORY_ROW_SIZE;
     boolean isActionSlot = rawSlot == _POS_SWITCH_PAGE_BUTTON

--- a/src/main/java/com/daveestar/bettervanilla/utils/CustomGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/utils/CustomGUI.java
@@ -184,7 +184,13 @@ public class CustomGUI implements Listener {
 
     Player p = (Player) e.getWhoClicked();
 
-    if (!allowMove) {
+    if (allowMove) {
+      if (slot >= _gui.getSize() - _INVENTORY_ROW_SIZE) {
+        e.setCancelled(true);
+      } else {
+        return;
+      }
+    } else {
       e.setCancelled(true);
 
       if (isItemSlot && e.getCursor().getType() == Material.AIR) {
@@ -207,14 +213,8 @@ public class CustomGUI implements Listener {
         }
       }
 
-      if (isActionSlot) {
-        // still allow actions below
-      } else {
+      if (!isActionSlot) {
         return;
-      }
-    } else {
-      if (isActionSlot || isItemSlot) {
-        e.setCancelled(true);
       }
     }
 

--- a/src/main/java/com/daveestar/bettervanilla/utils/CustomGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/utils/CustomGUI.java
@@ -172,60 +172,60 @@ public class CustomGUI implements Listener {
 
   @EventHandler
   private void _onInventoryClick(InventoryClickEvent e) {
-    if (!e.getView().getTopInventory().equals(_gui))
+    if (!e.getInventory().equals(_gui))
       return;
 
     boolean allowMove = _options.contains(Option.ALLOW_ITEM_MOVEMENT);
-
-    int slot = e.getRawSlot();
-    boolean isActionSlot = slot == _POS_SWITCH_PAGE_BUTTON
-        || (slot == _POS_BACK_BUTTON && _parentMenu != null);
-    boolean isItemSlot = _slotKeyMap.containsKey(slot);
-
     Player p = (Player) e.getWhoClicked();
+    int rawSlot = e.getRawSlot();
+    int topSize = _gui.getSize();
 
-    if (allowMove) {
-      if (slot >= _gui.getSize() - _INVENTORY_ROW_SIZE) {
-        e.setCancelled(true);
-      } else {
-        return;
-      }
-    } else {
-      e.setCancelled(true);
+    if (rawSlot >= topSize)
+      return; // player inventory interaction
 
-      if (isItemSlot && e.getCursor().getType() == Material.AIR) {
-        ItemStack item = _gui.getItem(slot);
-        if (item != null) {
-          if (e.isShiftClick()) {
-            Map<Integer, ItemStack> left = p.getInventory().addItem(item.clone());
-            if (left.isEmpty()) {
-              _gui.setItem(slot, null);
-              setEntryItem(_slotKeyMap.get(slot), null);
-            } else {
-              p.playSound(p, Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
-            }
+    boolean isNavSlot = rawSlot >= topSize - _INVENTORY_ROW_SIZE;
+    boolean isActionSlot = rawSlot == _POS_SWITCH_PAGE_BUTTON
+        || (rawSlot == _POS_BACK_BUTTON && _parentMenu != null);
+    boolean isItemSlot = _slotKeyMap.containsKey(rawSlot);
+
+    if (allowMove && !isNavSlot && !isActionSlot) {
+      // allow default item movement in the editable area
+      return;
+    }
+
+    e.setCancelled(true);
+
+    if (!allowMove && isItemSlot && e.getCursor().getType() == Material.AIR) {
+      ItemStack item = _gui.getItem(rawSlot);
+      if (item != null) {
+        if (e.isShiftClick()) {
+          Map<Integer, ItemStack> left = p.getInventory().addItem(item.clone());
+          if (left.isEmpty()) {
+            _gui.setItem(rawSlot, null);
+            setEntryItem(_slotKeyMap.get(rawSlot), null);
           } else {
-            p.setItemOnCursor(item.clone());
-            _gui.setItem(slot, null);
-            setEntryItem(_slotKeyMap.get(slot), null);
+            p.playSound(p, Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
           }
-          return;
+        } else {
+          p.setItemOnCursor(item.clone());
+          _gui.setItem(rawSlot, null);
+          setEntryItem(_slotKeyMap.get(rawSlot), null);
         }
-      }
-
-      if (!isActionSlot) {
         return;
       }
     }
 
-    if (slot == _POS_SWITCH_PAGE_BUTTON) {
+    if (!isActionSlot && !isItemSlot)
+      return;
+
+    if (rawSlot == _POS_SWITCH_PAGE_BUTTON) {
       _handlePageSwitch(p, e.isRightClick());
       p.playSound(p, Sound.UI_BUTTON_CLICK, 0.5F, 1);
-    } else if (slot == _POS_BACK_BUTTON && _parentMenu != null) {
+    } else if (rawSlot == _POS_BACK_BUTTON && _parentMenu != null) {
       p.playSound(p, Sound.UI_BUTTON_CLICK, 0.5F, 1);
       _parentMenu.open(p);
-    } else if (_slotKeyMap.containsKey(slot)) {
-      _handleItemClick(p, _slotKeyMap.get(slot), e.isShiftClick(), e.isRightClick());
+    } else if (_slotKeyMap.containsKey(rawSlot)) {
+      _handleItemClick(p, _slotKeyMap.get(rawSlot), e.isShiftClick(), e.isRightClick());
     } else {
       p.playSound(p, Sound.ENTITY_VILLAGER_NO, 0.5F, 1);
     }

--- a/src/main/java/com/daveestar/bettervanilla/utils/ItemStackUtils.java
+++ b/src/main/java/com/daveestar/bettervanilla/utils/ItemStackUtils.java
@@ -30,10 +30,20 @@ public final class ItemStackUtils {
   }
 
   public static ItemStack[] deserializeArray(List<?> data) {
-    return Optional.ofNullable(data).orElse(Collections.emptyList()).stream()
-        .filter(Map.class::isInstance)
-        .map(Map.class::cast)
-        .map(ItemStackUtils::deserialize)
-        .toArray(ItemStack[]::new);
+    List<?> list = Optional.ofNullable(data).orElse(Collections.emptyList());
+    ItemStack[] result = new ItemStack[list.size()];
+
+    for (int i = 0; i < list.size(); i++) {
+      Object obj = list.get(i);
+      if (obj instanceof Map) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) obj;
+        result[i] = deserialize(map);
+      } else {
+        result[i] = null;
+      }
+    }
+
+    return result;
   }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -58,3 +58,8 @@ commands:
     description: Manage player and group permissions.
     usage: /permissions
     permission: bettervanilla.permissions
+  backpack:
+    aliases: [bp]
+    description: Open your backpack.
+    usage: /backpack
+    permission: bettervanilla.backpack


### PR DESCRIPTION
## Summary
- split backpack configuration into new `BackpackSettingsGUI`
- refactor `AdminSettingsGUI` to open the new backpack menu

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700da867288320aee3f96af70faa97