### PR TITLE
Add configurable vein miner settings

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/events/VeinMiningChopping.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/VeinMiningChopping.java
@@ -61,7 +61,7 @@ public class VeinMiningChopping implements Listener {
     boolean isVeinMinerBlock = _isVeinMinerBlock(originBlockType);
 
     if (isValidPickaxe && isVeinMinerBlock) {
-      List<Block> veinBlocks = _getVeinBlocks(originBlock);
+      List<Block> veinBlocks = _getVeinBlocks(originBlock, _settingsManager.getVeinMinerMaxVeinSize());
 
       for (Block veinBlock : veinBlocks) {
         veinBlock.breakNaturally(tool, true, true);
@@ -80,7 +80,7 @@ public class VeinMiningChopping implements Listener {
     boolean isVeinChopperBlock = _isVeinChopperBlock(originBlockType);
 
     if (isValidAxe && isVeinChopperBlock) {
-      List<Block> veinBlocks = _getVeinBlocks(originBlock);
+      List<Block> veinBlocks = _getVeinBlocks(originBlock, _settingsManager.getVeinChopperMaxVeinSize());
 
       for (Block veinBlock : veinBlocks) {
         veinBlock.breakNaturally(tool, true, true);
@@ -120,8 +120,7 @@ public class VeinMiningChopping implements Listener {
     return true;
   }
 
-  private List<Block> _getVeinBlocks(Block originBlock) {
-    int limit = 100; // safety valve; make this configurable ???
+  private List<Block> _getVeinBlocks(Block originBlock, int limit) {
     Set<Block> visited = new HashSet<>();
     Queue<Block> queue = new ArrayDeque<>();
 
@@ -166,28 +165,18 @@ public class VeinMiningChopping implements Listener {
   }
 
   private boolean _isVeinMinerBlock(Material blockType) {
-    return blockType == Material.COAL_ORE || blockType == Material.IRON_ORE || blockType == Material.GOLD_ORE ||
-        blockType == Material.REDSTONE_ORE || blockType == Material.LAPIS_ORE || blockType == Material.DIAMOND_ORE ||
-        blockType == Material.EMERALD_ORE || blockType == Material.COPPER_ORE || blockType == Material.NETHER_QUARTZ_ORE
-        || blockType == Material.NETHER_GOLD_ORE || blockType == Material.DEEPSLATE_COAL_ORE ||
-        blockType == Material.DEEPSLATE_IRON_ORE || blockType == Material.DEEPSLATE_GOLD_ORE ||
-        blockType == Material.DEEPSLATE_REDSTONE_ORE || blockType == Material.DEEPSLATE_LAPIS_ORE ||
-        blockType == Material.DEEPSLATE_DIAMOND_ORE || blockType == Material.DEEPSLATE_COPPER_ORE;
+    return _settingsManager.getVeinMinerAllowedBlocks().contains(blockType.name());
   }
 
   private boolean _isVeinChopperBlock(Material blockType) {
-    return blockType == Material.OAK_LOG || blockType == Material.SPRUCE_LOG || blockType == Material.BIRCH_LOG ||
-        blockType == Material.JUNGLE_LOG || blockType == Material.ACACIA_LOG || blockType == Material.DARK_OAK_LOG ||
-        blockType == Material.MANGROVE_LOG || blockType == Material.CHERRY_LOG;
+    return _settingsManager.getVeinChopperAllowedBlocks().contains(blockType.name());
   }
 
   private boolean _isValidAxe(Material tool) {
-    return tool == Material.WOODEN_AXE || tool == Material.STONE_AXE || tool == Material.IRON_AXE ||
-        tool == Material.GOLDEN_AXE || tool == Material.DIAMOND_AXE || tool == Material.NETHERITE_AXE;
+    return _settingsManager.getVeinChopperAllowedTools().contains(tool.name());
   }
 
   private boolean _isValidPickaxe(Material tool) {
-    return tool == Material.WOODEN_PICKAXE || tool == Material.STONE_PICKAXE || tool == Material.IRON_PICKAXE ||
-        tool == Material.GOLDEN_PICKAXE || tool == Material.DIAMOND_PICKAXE || tool == Material.NETHERITE_PICKAXE;
+    return _settingsManager.getVeinMinerAllowedTools().contains(tool.name());
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/events/VeinMiningChopping.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/VeinMiningChopping.java
@@ -69,6 +69,10 @@ public class VeinMiningChopping implements Listener {
         if (!_applyDurabilityDamage(tool, p))
           break;
       }
+
+      if (veinBlocks.size() > 1 && _settingsManager.getVeinMinerSound()) {
+        p.playSound(p.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 0.7f, 1);
+      }
     }
   }
 
@@ -88,6 +92,10 @@ public class VeinMiningChopping implements Listener {
         if (!_applyDurabilityDamage(tool, p))
           break;
 
+      }
+
+      if (veinBlocks.size() > 1 && _settingsManager.getVeinChopperSound()) {
+        p.playSound(p.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 0.7f, 1);
       }
 
     }

--- a/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
@@ -22,6 +22,8 @@ import com.daveestar.bettervanilla.manager.AFKManager;
 import com.daveestar.bettervanilla.manager.MaintenanceManager;
 import com.daveestar.bettervanilla.manager.SettingsManager;
 import com.daveestar.bettervanilla.utils.CustomGUI;
+import com.daveestar.bettervanilla.gui.VeinMinerSettingsGUI;
+import com.daveestar.bettervanilla.gui.VeinChopperSettingsGUI;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
@@ -37,6 +39,8 @@ public class AdminSettingsGUI implements Listener {
   private final Map<UUID, CustomGUI> _maintenanceMessagePending;
   private final Map<UUID, CustomGUI> _motdPending;
   private final BackpackSettingsGUI _backpackSettingsGUI;
+  private final VeinMinerSettingsGUI _veinMinerSettingsGUI;
+  private final VeinChopperSettingsGUI _veinChopperSettingsGUI;
 
   public AdminSettingsGUI() {
     _plugin = Main.getInstance();
@@ -47,6 +51,8 @@ public class AdminSettingsGUI implements Listener {
     _maintenanceMessagePending = new HashMap<>();
     _motdPending = new HashMap<>();
     _backpackSettingsGUI = new BackpackSettingsGUI();
+    _veinMinerSettingsGUI = new VeinMinerSettingsGUI();
+    _veinChopperSettingsGUI = new VeinChopperSettingsGUI();
     _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
   }
 
@@ -201,16 +207,14 @@ public class AdminSettingsGUI implements Listener {
     actions.put("veinminer", new CustomGUI.ClickAction() {
       @Override
       public void onLeftClick(Player p) {
-        _toggleVeinMiner(p);
-        displayGUI(p, parentMenu);
+        _veinMinerSettingsGUI.displayGUI(p, gui);
       }
     });
 
     actions.put("veinchopper", new CustomGUI.ClickAction() {
       @Override
       public void onLeftClick(Player p) {
-        _toggleVeinChopper(p);
-        displayGUI(p, parentMenu);
+        _veinChopperSettingsGUI.displayGUI(p, gui);
       }
     });
 
@@ -463,7 +467,7 @@ public class AdminSettingsGUI implements Listener {
           "",
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
               + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Open")
           .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
       item.setItemMeta(meta);
     }
@@ -485,7 +489,7 @@ public class AdminSettingsGUI implements Listener {
           "",
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
               + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Open")
           .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
       item.setItemMeta(meta);
     }

--- a/src/main/java/com/daveestar/bettervanilla/gui/MaterialToggleGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/MaterialToggleGUI.java
@@ -71,7 +71,7 @@ public class MaterialToggleGUI implements Listener {
       actions.put(mat.name(), new CustomGUI.ClickAction() {
         @Override
         public void onLeftClick(Player player) {
-          List<String> list = _getList.get();
+          List<String> list = new java.util.ArrayList<>(_getList.get());
           if (list.contains(mat.name())) {
             list.remove(mat.name());
           } else {

--- a/src/main/java/com/daveestar/bettervanilla/gui/MaterialToggleGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/MaterialToggleGUI.java
@@ -1,15 +1,19 @@
 package com.daveestar.bettervanilla.gui;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -45,16 +49,22 @@ public class MaterialToggleGUI implements Listener {
       ItemStack item = new ItemStack(mat);
       ItemMeta meta = item.getItemMeta();
       if (meta != null) {
-        meta.displayName(Component.text(ChatColor.YELLOW + mat.name() + ChatColor.GRAY + " : "
-            + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED")));
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+        meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + mat.name()));
+        meta.lore(Arrays.asList(
+            ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: " + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+            ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+            .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
         item.setItemMeta(meta);
       }
       entries.put(mat.name(), item);
     }
 
     int rows = Math.max(1, (int) Math.ceil(entries.size() / 9.0)) + 1;
-    CustomGUI gui = new CustomGUI(_plugin, p, ChatColor.YELLOW + "" + ChatColor.BOLD + "» " + _title,
-        entries, rows, null, parent, EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
+    CustomGUI gui = new CustomGUI(_plugin, p,
+        ChatColor.YELLOW + "" + ChatColor.BOLD + "» " + _title,
+        entries, rows, null, parent,
+        EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
 
     Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
     for (Material mat : _materials) {

--- a/src/main/java/com/daveestar/bettervanilla/gui/MaterialToggleGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/MaterialToggleGUI.java
@@ -1,0 +1,79 @@
+package com.daveestar.bettervanilla.gui;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.utils.CustomGUI;
+
+import net.kyori.adventure.text.Component;
+import net.md_5.bungee.api.ChatColor;
+
+public class MaterialToggleGUI implements Listener {
+  private final Main _plugin;
+  private final String _title;
+  private final List<Material> _materials;
+  private final Supplier<List<String>> _getList;
+  private final Consumer<List<String>> _setList;
+
+  public MaterialToggleGUI(String title, List<Material> materials,
+      Supplier<List<String>> getter, Consumer<List<String>> setter) {
+    _plugin = Main.getInstance();
+    _title = title;
+    _materials = materials;
+    _getList = getter;
+    _setList = setter;
+    _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
+  }
+
+  public void displayGUI(Player p, CustomGUI parent) {
+    Map<String, ItemStack> entries = new HashMap<>();
+    List<String> allowed = _getList.get();
+
+    for (Material mat : _materials) {
+      boolean state = allowed.contains(mat.name());
+      ItemStack item = new ItemStack(mat);
+      ItemMeta meta = item.getItemMeta();
+      if (meta != null) {
+        meta.displayName(Component.text(ChatColor.YELLOW + mat.name() + ChatColor.GRAY + " : "
+            + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED")));
+        item.setItemMeta(meta);
+      }
+      entries.put(mat.name(), item);
+    }
+
+    int rows = Math.max(1, (int) Math.ceil(entries.size() / 9.0)) + 1;
+    CustomGUI gui = new CustomGUI(_plugin, p, ChatColor.YELLOW + "" + ChatColor.BOLD + "» " + _title,
+        entries, rows, null, parent, EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
+
+    Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
+    for (Material mat : _materials) {
+      actions.put(mat.name(), new CustomGUI.ClickAction() {
+        @Override
+        public void onLeftClick(Player player) {
+          List<String> list = _getList.get();
+          if (list.contains(mat.name())) {
+            list.remove(mat.name());
+          } else {
+            list.add(mat.name());
+          }
+          _setList.accept(list);
+          displayGUI(player, parent);
+        }
+      });
+    }
+
+    gui.setClickActions(actions);
+    gui.open(p);
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/gui/VeinChopperSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/VeinChopperSettingsGUI.java
@@ -54,14 +54,16 @@ public class VeinChopperSettingsGUI implements Listener {
     Map<String, ItemStack> entries = new HashMap<>();
     entries.put("enabled", _createEnabledItem());
     entries.put("maxsize", _createMaxSizeItem());
+    entries.put("sound", _createSoundItem());
     entries.put("tools", _createToolsItem());
     entries.put("blocks", _createBlocksItem());
 
     Map<String, Integer> customSlots = new HashMap<>();
     customSlots.put("enabled", 1);
     customSlots.put("maxsize", 3);
-    customSlots.put("tools", 5);
-    customSlots.put("blocks", 7);
+    customSlots.put("sound", 5);
+    customSlots.put("tools", 11);
+    customSlots.put("blocks", 15);
 
     CustomGUI gui = new CustomGUI(_plugin, p,
         ChatColor.YELLOW + "" + ChatColor.BOLD + "» Vein Chopper Settings",
@@ -83,6 +85,14 @@ public class VeinChopperSettingsGUI implements Listener {
         player.sendMessage(Main.getPrefix() + "Enter max vein size (1-1024):");
         _sizePending.put(player.getUniqueId(), parent);
         player.closeInventory();
+      }
+    });
+    actions.put("sound", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        boolean newState = !_settingsManager.getVeinChopperSound();
+        _settingsManager.setVeinChopperSound(newState);
+        displayGUI(player, parent);
       }
     });
     actions.put("tools", new CustomGUI.ClickAction() {
@@ -128,6 +138,22 @@ public class VeinChopperSettingsGUI implements Listener {
       meta.lore(Arrays.asList(
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + val,
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Set value")
+          .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createSoundItem() {
+    boolean state = _settingsManager.getVeinChopperSound();
+    ItemStack item = new ItemStack(Material.NOTE_BLOCK);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Sound"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
           .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
       item.setItemMeta(meta);
     }

--- a/src/main/java/com/daveestar/bettervanilla/gui/VeinChopperSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/VeinChopperSettingsGUI.java
@@ -1,0 +1,159 @@
+package com.daveestar.bettervanilla.gui;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.SettingsManager;
+import com.daveestar.bettervanilla.utils.CustomGUI;
+
+import net.kyori.adventure.text.Component;
+import net.md_5.bungee.api.ChatColor;
+
+public class VeinChopperSettingsGUI implements Listener {
+  private final Main _plugin;
+  private final SettingsManager _settingsManager;
+  private final MaterialToggleGUI _toolsGUI;
+  private final MaterialToggleGUI _blocksGUI;
+
+  public VeinChopperSettingsGUI() {
+    _plugin = Main.getInstance();
+    _settingsManager = _plugin.getSettingsManager();
+    _toolsGUI = new MaterialToggleGUI("Vein Chopper Tools",
+        SettingsManager.DEFAULT_VEIN_CHOPPER_TOOLS.stream().map(Material::valueOf).toList(),
+        () -> _settingsManager.getVeinChopperAllowedTools(),
+        list -> _settingsManager.setVeinChopperAllowedTools(list));
+    _blocksGUI = new MaterialToggleGUI("Vein Chopper Blocks",
+        SettingsManager.DEFAULT_VEIN_CHOPPER_BLOCKS.stream().map(Material::valueOf).toList(),
+        () -> _settingsManager.getVeinChopperAllowedBlocks(),
+        list -> _settingsManager.setVeinChopperAllowedBlocks(list));
+    _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
+  }
+
+  public void displayGUI(Player p, CustomGUI parent) {
+    Map<String, ItemStack> entries = new HashMap<>();
+    entries.put("enabled", _createEnabledItem());
+    entries.put("maxsize", _createMaxSizeItem());
+    entries.put("tools", _createToolsItem());
+    entries.put("blocks", _createBlocksItem());
+
+    Map<String, Integer> customSlots = new HashMap<>();
+    customSlots.put("enabled", 1);
+    customSlots.put("maxsize", 3);
+    customSlots.put("tools", 5);
+    customSlots.put("blocks", 7);
+
+    CustomGUI gui = new CustomGUI(_plugin, p,
+        ChatColor.YELLOW + "" + ChatColor.BOLD + "» Vein Chopper Settings",
+        entries, 3, customSlots, parent,
+        EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
+
+    Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
+    actions.put("enabled", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        boolean newState = !_settingsManager.getVeinChopper();
+        _settingsManager.setVeinChopper(newState);
+        displayGUI(player, parent);
+      }
+    });
+    actions.put("maxsize", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        int newVal = _settingsManager.getVeinChopperMaxVeinSize() + 1;
+        _settingsManager.setVeinChopperMaxVeinSize(newVal);
+        displayGUI(player, parent);
+      }
+
+      @Override
+      public void onRightClick(Player player) {
+        int newVal = Math.max(1, _settingsManager.getVeinChopperMaxVeinSize() - 1);
+        _settingsManager.setVeinChopperMaxVeinSize(newVal);
+        displayGUI(player, parent);
+      }
+    });
+    actions.put("tools", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toolsGUI.displayGUI(player, gui);
+      }
+    });
+    actions.put("blocks", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _blocksGUI.displayGUI(player, gui);
+      }
+    });
+
+    gui.setClickActions(actions);
+    gui.open(p);
+  }
+
+  private ItemStack _createEnabledItem() {
+    boolean state = _settingsManager.getVeinChopper();
+    ItemStack item = new ItemStack(Material.DIAMOND_AXE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Enabled"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createMaxSizeItem() {
+    int val = _settingsManager.getVeinChopperMaxVeinSize();
+    ItemStack item = new ItemStack(Material.PAPER);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Max Vein Size"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + val,
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: +1",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Right-Click: -1")
+          .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createToolsItem() {
+    ItemStack item = new ItemStack(Material.IRON_AXE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Allowed Tools"));
+      meta.lore(List.of(Component.text(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Open")));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createBlocksItem() {
+    ItemStack item = new ItemStack(Material.OAK_LOG);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Allowed Blocks"));
+      meta.lore(List.of(Component.text(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Open")));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/gui/VeinMinerSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/VeinMinerSettingsGUI.java
@@ -54,14 +54,16 @@ public class VeinMinerSettingsGUI implements Listener {
     Map<String, ItemStack> entries = new HashMap<>();
     entries.put("enabled", _createEnabledItem());
     entries.put("maxsize", _createMaxSizeItem());
+    entries.put("sound", _createSoundItem());
     entries.put("tools", _createToolsItem());
     entries.put("blocks", _createBlocksItem());
 
     Map<String, Integer> customSlots = new HashMap<>();
     customSlots.put("enabled", 1);
     customSlots.put("maxsize", 3);
-    customSlots.put("tools", 5);
-    customSlots.put("blocks", 7);
+    customSlots.put("sound", 5);
+    customSlots.put("tools", 11);
+    customSlots.put("blocks", 15);
 
     CustomGUI gui = new CustomGUI(_plugin, p,
         ChatColor.YELLOW + "" + ChatColor.BOLD + "» Vein Miner Settings",
@@ -83,6 +85,14 @@ public class VeinMinerSettingsGUI implements Listener {
         player.sendMessage(Main.getPrefix() + "Enter max vein size (1-1024):");
         _sizePending.put(player.getUniqueId(), parent);
         player.closeInventory();
+      }
+    });
+    actions.put("sound", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        boolean newState = !_settingsManager.getVeinMinerSound();
+        _settingsManager.setVeinMinerSound(newState);
+        displayGUI(player, parent);
       }
     });
     actions.put("tools", new CustomGUI.ClickAction() {
@@ -128,6 +138,22 @@ public class VeinMinerSettingsGUI implements Listener {
       meta.lore(Arrays.asList(
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + val,
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Set value")
+          .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createSoundItem() {
+    boolean state = _settingsManager.getVeinMinerSound();
+    ItemStack item = new ItemStack(Material.NOTE_BLOCK);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Sound"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
           .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
       item.setItemMeta(meta);
     }

--- a/src/main/java/com/daveestar/bettervanilla/gui/VeinMinerSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/VeinMinerSettingsGUI.java
@@ -6,9 +6,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemFlag;
@@ -19,7 +21,9 @@ import com.daveestar.bettervanilla.Main;
 import com.daveestar.bettervanilla.manager.SettingsManager;
 import com.daveestar.bettervanilla.utils.CustomGUI;
 
+import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.md_5.bungee.api.ChatColor;
 
 public class VeinMinerSettingsGUI implements Listener {
@@ -27,18 +31,22 @@ public class VeinMinerSettingsGUI implements Listener {
   private final SettingsManager _settingsManager;
   private final MaterialToggleGUI _toolsGUI;
   private final MaterialToggleGUI _blocksGUI;
+  private final Map<UUID, CustomGUI> _sizePending;
 
   public VeinMinerSettingsGUI() {
     _plugin = Main.getInstance();
     _settingsManager = _plugin.getSettingsManager();
     _toolsGUI = new MaterialToggleGUI("Vein Miner Tools",
-        SettingsManager.DEFAULT_VEIN_MINER_TOOLS.stream().map(Material::valueOf).toList(),
+        SettingsManager.DEFAULT_VEIN_MINER_TOOLS.stream()
+            .map(Material::matchMaterial).filter(Objects::nonNull).toList(),
         () -> _settingsManager.getVeinMinerAllowedTools(),
         list -> _settingsManager.setVeinMinerAllowedTools(list));
     _blocksGUI = new MaterialToggleGUI("Vein Miner Blocks",
-        SettingsManager.DEFAULT_VEIN_MINER_BLOCKS.stream().map(Material::valueOf).toList(),
+        SettingsManager.DEFAULT_VEIN_MINER_BLOCKS.stream()
+            .map(Material::matchMaterial).filter(Objects::nonNull).toList(),
         () -> _settingsManager.getVeinMinerAllowedBlocks(),
         list -> _settingsManager.setVeinMinerAllowedBlocks(list));
+    _sizePending = new HashMap<>();
     _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
   }
 
@@ -72,16 +80,9 @@ public class VeinMinerSettingsGUI implements Listener {
     actions.put("maxsize", new CustomGUI.ClickAction() {
       @Override
       public void onLeftClick(Player player) {
-        int newVal = _settingsManager.getVeinMinerMaxVeinSize() + 1;
-        _settingsManager.setVeinMinerMaxVeinSize(newVal);
-        displayGUI(player, parent);
-      }
-
-      @Override
-      public void onRightClick(Player player) {
-        int newVal = Math.max(1, _settingsManager.getVeinMinerMaxVeinSize() - 1);
-        _settingsManager.setVeinMinerMaxVeinSize(newVal);
-        displayGUI(player, parent);
+        player.sendMessage(Main.getPrefix() + "Enter max vein size (1-1024):");
+        _sizePending.put(player.getUniqueId(), parent);
+        player.closeInventory();
       }
     });
     actions.put("tools", new CustomGUI.ClickAction() {
@@ -126,8 +127,7 @@ public class VeinMinerSettingsGUI implements Listener {
       meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Max Vein Size"));
       meta.lore(Arrays.asList(
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + val,
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: +1",
-          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Right-Click: -1")
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Set value")
           .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
       item.setItemMeta(meta);
     }
@@ -155,5 +155,34 @@ public class VeinMinerSettingsGUI implements Listener {
       item.setItemMeta(meta);
     }
     return item;
+  }
+
+  @EventHandler
+  public void onPlayerChat(AsyncChatEvent e) {
+    Player p = e.getPlayer();
+    UUID id = p.getUniqueId();
+
+    if (_sizePending.containsKey(id)) {
+      e.setCancelled(true);
+      String content = ((TextComponent) e.message()).content();
+
+      try {
+        int val = Integer.parseInt(content);
+        if (val < 1 || val > 1024) {
+          p.sendMessage(Main.getPrefix() + ChatColor.RED + "Value must be between 1 and 1024.");
+          return;
+        }
+
+        _plugin.getServer().getScheduler().runTask(_plugin, () -> {
+          _settingsManager.setVeinMinerMaxVeinSize(val);
+          p.sendMessage(Main.getPrefix() + "Max vein size set to: " + ChatColor.YELLOW + val);
+          p.playSound(p, Sound.ENTITY_PLAYER_LEVELUP, 0.5F, 1);
+          CustomGUI parent = _sizePending.remove(id);
+          displayGUI(p, parent);
+        });
+      } catch (NumberFormatException ex) {
+        p.sendMessage(Main.getPrefix() + ChatColor.RED + "Please provide a valid number.");
+      }
+    }
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/gui/VeinMinerSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/VeinMinerSettingsGUI.java
@@ -1,0 +1,159 @@
+package com.daveestar.bettervanilla.gui;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.SettingsManager;
+import com.daveestar.bettervanilla.utils.CustomGUI;
+
+import net.kyori.adventure.text.Component;
+import net.md_5.bungee.api.ChatColor;
+
+public class VeinMinerSettingsGUI implements Listener {
+  private final Main _plugin;
+  private final SettingsManager _settingsManager;
+  private final MaterialToggleGUI _toolsGUI;
+  private final MaterialToggleGUI _blocksGUI;
+
+  public VeinMinerSettingsGUI() {
+    _plugin = Main.getInstance();
+    _settingsManager = _plugin.getSettingsManager();
+    _toolsGUI = new MaterialToggleGUI("Vein Miner Tools",
+        SettingsManager.DEFAULT_VEIN_MINER_TOOLS.stream().map(Material::valueOf).toList(),
+        () -> _settingsManager.getVeinMinerAllowedTools(),
+        list -> _settingsManager.setVeinMinerAllowedTools(list));
+    _blocksGUI = new MaterialToggleGUI("Vein Miner Blocks",
+        SettingsManager.DEFAULT_VEIN_MINER_BLOCKS.stream().map(Material::valueOf).toList(),
+        () -> _settingsManager.getVeinMinerAllowedBlocks(),
+        list -> _settingsManager.setVeinMinerAllowedBlocks(list));
+    _plugin.getServer().getPluginManager().registerEvents(this, _plugin);
+  }
+
+  public void displayGUI(Player p, CustomGUI parent) {
+    Map<String, ItemStack> entries = new HashMap<>();
+    entries.put("enabled", _createEnabledItem());
+    entries.put("maxsize", _createMaxSizeItem());
+    entries.put("tools", _createToolsItem());
+    entries.put("blocks", _createBlocksItem());
+
+    Map<String, Integer> customSlots = new HashMap<>();
+    customSlots.put("enabled", 1);
+    customSlots.put("maxsize", 3);
+    customSlots.put("tools", 5);
+    customSlots.put("blocks", 7);
+
+    CustomGUI gui = new CustomGUI(_plugin, p,
+        ChatColor.YELLOW + "" + ChatColor.BOLD + "» Vein Miner Settings",
+        entries, 3, customSlots, parent,
+        EnumSet.of(CustomGUI.Option.DISABLE_PAGE_BUTTON));
+
+    Map<String, CustomGUI.ClickAction> actions = new HashMap<>();
+    actions.put("enabled", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        boolean newState = !_settingsManager.getVeinMiner();
+        _settingsManager.setVeinMiner(newState);
+        displayGUI(player, parent);
+      }
+    });
+    actions.put("maxsize", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        int newVal = _settingsManager.getVeinMinerMaxVeinSize() + 1;
+        _settingsManager.setVeinMinerMaxVeinSize(newVal);
+        displayGUI(player, parent);
+      }
+
+      @Override
+      public void onRightClick(Player player) {
+        int newVal = Math.max(1, _settingsManager.getVeinMinerMaxVeinSize() - 1);
+        _settingsManager.setVeinMinerMaxVeinSize(newVal);
+        displayGUI(player, parent);
+      }
+    });
+    actions.put("tools", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _toolsGUI.displayGUI(player, gui);
+      }
+    });
+    actions.put("blocks", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player player) {
+        _blocksGUI.displayGUI(player, gui);
+      }
+    });
+
+    gui.setClickActions(actions);
+    gui.open(p);
+  }
+
+  private ItemStack _createEnabledItem() {
+    boolean state = _settingsManager.getVeinMiner();
+    ItemStack item = new ItemStack(Material.DIAMOND_PICKAXE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Enabled"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createMaxSizeItem() {
+    int val = _settingsManager.getVeinMinerMaxVeinSize();
+    ItemStack item = new ItemStack(Material.PAPER);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Max Vein Size"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Current: " + ChatColor.YELLOW + val,
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: +1",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Right-Click: -1")
+          .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createToolsItem() {
+    ItemStack item = new ItemStack(Material.IRON_PICKAXE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Allowed Tools"));
+      meta.lore(List.of(Component.text(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Open")));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack _createBlocksItem() {
+    ItemStack item = new ItemStack(Material.COAL_ORE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Allowed Blocks"));
+      meta.lore(List.of(Component.text(ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Open")));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -1,5 +1,7 @@
 package com.daveestar.bettervanilla.manager;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.configuration.file.FileConfiguration;
@@ -9,6 +11,25 @@ import com.daveestar.bettervanilla.utils.Config;
 public class SettingsManager {
   private Config _config;
   private FileConfiguration _fileConfig;
+
+  public static final List<String> DEFAULT_VEIN_MINER_TOOLS = Arrays.asList(
+      "WOODEN_PICKAXE", "STONE_PICKAXE", "IRON_PICKAXE", "GOLDEN_PICKAXE",
+      "DIAMOND_PICKAXE", "NETHERITE_PICKAXE");
+
+  public static final List<String> DEFAULT_VEIN_MINER_BLOCKS = Arrays.asList(
+      "COAL_ORE", "IRON_ORE", "GOLD_ORE", "REDSTONE_ORE", "LAPIS_ORE",
+      "DIAMOND_ORE", "EMERALD_ORE", "COPPER_ORE", "NETHER_QUARTZ_ORE",
+      "NETHER_GOLD_ORE", "DEEPSLATE_COAL_ORE", "DEEPSLATE_IRON_ORE",
+      "DEEPSLATE_GOLD_ORE", "DEEPSLATE_REDSTONE_ORE", "DEEPSLATE_LAPIS_ORE",
+      "DEEPSLATE_DIAMOND_ORE", "DEEPSLATE_COPPER_ORE");
+
+  public static final List<String> DEFAULT_VEIN_CHOPPER_TOOLS = Arrays.asList(
+      "WOODEN_AXE", "STONE_AXE", "IRON_AXE", "GOLDEN_AXE",
+      "DIAMOND_AXE", "NETHERITE_AXE");
+
+  public static final List<String> DEFAULT_VEIN_CHOPPER_BLOCKS = Arrays.asList(
+      "OAK_LOG", "SPRUCE_LOG", "BIRCH_LOG", "JUNGLE_LOG", "ACACIA_LOG",
+      "DARK_OAK_LOG", "MANGROVE_LOG", "CHERRY_LOG");
 
   public SettingsManager(Config config) {
     _config = config;
@@ -216,6 +237,64 @@ public class SettingsManager {
 
   public void setVeinChopper(boolean value) {
     _fileConfig.set("global.veinchopper", value);
+    _config.save();
+  }
+
+  public int getVeinMinerMaxVeinSize() {
+    return _fileConfig.getInt("global.veinminer.maxveinsize", 100);
+  }
+
+  public void setVeinMinerMaxVeinSize(int value) {
+    _fileConfig.set("global.veinminer.maxveinsize", value);
+    _config.save();
+  }
+
+  public int getVeinChopperMaxVeinSize() {
+    return _fileConfig.getInt("global.veinchopper.maxveinsize", 100);
+  }
+
+  public void setVeinChopperMaxVeinSize(int value) {
+    _fileConfig.set("global.veinchopper.maxveinsize", value);
+    _config.save();
+  }
+
+  public List<String> getVeinMinerAllowedTools() {
+    List<String> list = _fileConfig.getStringList("global.veinminer.allowedtools");
+    return list == null || list.isEmpty() ? DEFAULT_VEIN_MINER_TOOLS : list;
+  }
+
+  public void setVeinMinerAllowedTools(List<String> tools) {
+    _fileConfig.set("global.veinminer.allowedtools", tools);
+    _config.save();
+  }
+
+  public List<String> getVeinMinerAllowedBlocks() {
+    List<String> list = _fileConfig.getStringList("global.veinminer.allowedblocks");
+    return list == null || list.isEmpty() ? DEFAULT_VEIN_MINER_BLOCKS : list;
+  }
+
+  public void setVeinMinerAllowedBlocks(List<String> blocks) {
+    _fileConfig.set("global.veinminer.allowedblocks", blocks);
+    _config.save();
+  }
+
+  public List<String> getVeinChopperAllowedTools() {
+    List<String> list = _fileConfig.getStringList("global.veinchopper.allowedtools");
+    return list == null || list.isEmpty() ? DEFAULT_VEIN_CHOPPER_TOOLS : list;
+  }
+
+  public void setVeinChopperAllowedTools(List<String> tools) {
+    _fileConfig.set("global.veinchopper.allowedtools", tools);
+    _config.save();
+  }
+
+  public List<String> getVeinChopperAllowedBlocks() {
+    List<String> list = _fileConfig.getStringList("global.veinchopper.allowedblocks");
+    return list == null || list.isEmpty() ? DEFAULT_VEIN_CHOPPER_BLOCKS : list;
+  }
+
+  public void setVeinChopperAllowedBlocks(List<String> blocks) {
+    _fileConfig.set("global.veinchopper.allowedblocks", blocks);
     _config.save();
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -223,20 +223,20 @@ public class SettingsManager {
   }
 
   public boolean getVeinMiner() {
-    return _fileConfig.getBoolean("global.veinminer", false);
+    return _fileConfig.getBoolean("global.veinminer.enabled", false);
   }
 
   public void setVeinMiner(boolean value) {
-    _fileConfig.set("global.veinminer", value);
+    _fileConfig.set("global.veinminer.enabled", value);
     _config.save();
   }
 
   public boolean getVeinChopper() {
-    return _fileConfig.getBoolean("global.veinchopper", false);
+    return _fileConfig.getBoolean("global.veinchopper.enabled", false);
   }
 
   public void setVeinChopper(boolean value) {
-    _fileConfig.set("global.veinchopper", value);
+    _fileConfig.set("global.veinchopper.enabled", value);
     _config.save();
   }
 
@@ -260,7 +260,7 @@ public class SettingsManager {
 
   public List<String> getVeinMinerAllowedTools() {
     List<String> list = _fileConfig.getStringList("global.veinminer.allowedtools");
-    return list == null || list.isEmpty() ? DEFAULT_VEIN_MINER_TOOLS : list;
+    return list == null || list.isEmpty() ? new java.util.ArrayList<>(DEFAULT_VEIN_MINER_TOOLS) : list;
   }
 
   public void setVeinMinerAllowedTools(List<String> tools) {
@@ -270,7 +270,7 @@ public class SettingsManager {
 
   public List<String> getVeinMinerAllowedBlocks() {
     List<String> list = _fileConfig.getStringList("global.veinminer.allowedblocks");
-    return list == null || list.isEmpty() ? DEFAULT_VEIN_MINER_BLOCKS : list;
+    return list == null || list.isEmpty() ? new java.util.ArrayList<>(DEFAULT_VEIN_MINER_BLOCKS) : list;
   }
 
   public void setVeinMinerAllowedBlocks(List<String> blocks) {
@@ -280,7 +280,7 @@ public class SettingsManager {
 
   public List<String> getVeinChopperAllowedTools() {
     List<String> list = _fileConfig.getStringList("global.veinchopper.allowedtools");
-    return list == null || list.isEmpty() ? DEFAULT_VEIN_CHOPPER_TOOLS : list;
+    return list == null || list.isEmpty() ? new java.util.ArrayList<>(DEFAULT_VEIN_CHOPPER_TOOLS) : list;
   }
 
   public void setVeinChopperAllowedTools(List<String> tools) {
@@ -290,7 +290,7 @@ public class SettingsManager {
 
   public List<String> getVeinChopperAllowedBlocks() {
     List<String> list = _fileConfig.getStringList("global.veinchopper.allowedblocks");
-    return list == null || list.isEmpty() ? DEFAULT_VEIN_CHOPPER_BLOCKS : list;
+    return list == null || list.isEmpty() ? new java.util.ArrayList<>(DEFAULT_VEIN_CHOPPER_BLOCKS) : list;
   }
 
   public void setVeinChopperAllowedBlocks(List<String> blocks) {

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -244,6 +244,15 @@ public class SettingsManager {
     return _fileConfig.getInt("global.veinminer.maxveinsize", 100);
   }
 
+  public boolean getVeinMinerSound() {
+    return _fileConfig.getBoolean("global.veinminer.sound", true);
+  }
+
+  public void setVeinMinerSound(boolean value) {
+    _fileConfig.set("global.veinminer.sound", value);
+    _config.save();
+  }
+
   public void setVeinMinerMaxVeinSize(int value) {
     _fileConfig.set("global.veinminer.maxveinsize", value);
     _config.save();
@@ -253,14 +262,28 @@ public class SettingsManager {
     return _fileConfig.getInt("global.veinchopper.maxveinsize", 100);
   }
 
+  public boolean getVeinChopperSound() {
+    return _fileConfig.getBoolean("global.veinchopper.sound", true);
+  }
+
+  public void setVeinChopperSound(boolean value) {
+    _fileConfig.set("global.veinchopper.sound", value);
+    _config.save();
+  }
+
   public void setVeinChopperMaxVeinSize(int value) {
     _fileConfig.set("global.veinchopper.maxveinsize", value);
     _config.save();
   }
 
   public List<String> getVeinMinerAllowedTools() {
-    List<String> list = _fileConfig.getStringList("global.veinminer.allowedtools");
-    return list == null || list.isEmpty() ? new java.util.ArrayList<>(DEFAULT_VEIN_MINER_TOOLS) : list;
+    String path = "global.veinminer.allowedtools";
+    if (!_fileConfig.contains(path)) {
+      return new java.util.ArrayList<>(DEFAULT_VEIN_MINER_TOOLS);
+    }
+
+    List<String> list = _fileConfig.getStringList(path);
+    return list == null ? new java.util.ArrayList<>() : new java.util.ArrayList<>(list);
   }
 
   public void setVeinMinerAllowedTools(List<String> tools) {
@@ -269,8 +292,13 @@ public class SettingsManager {
   }
 
   public List<String> getVeinMinerAllowedBlocks() {
-    List<String> list = _fileConfig.getStringList("global.veinminer.allowedblocks");
-    return list == null || list.isEmpty() ? new java.util.ArrayList<>(DEFAULT_VEIN_MINER_BLOCKS) : list;
+    String path = "global.veinminer.allowedblocks";
+    if (!_fileConfig.contains(path)) {
+      return new java.util.ArrayList<>(DEFAULT_VEIN_MINER_BLOCKS);
+    }
+
+    List<String> list = _fileConfig.getStringList(path);
+    return list == null ? new java.util.ArrayList<>() : new java.util.ArrayList<>(list);
   }
 
   public void setVeinMinerAllowedBlocks(List<String> blocks) {
@@ -279,8 +307,13 @@ public class SettingsManager {
   }
 
   public List<String> getVeinChopperAllowedTools() {
-    List<String> list = _fileConfig.getStringList("global.veinchopper.allowedtools");
-    return list == null || list.isEmpty() ? new java.util.ArrayList<>(DEFAULT_VEIN_CHOPPER_TOOLS) : list;
+    String path = "global.veinchopper.allowedtools";
+    if (!_fileConfig.contains(path)) {
+      return new java.util.ArrayList<>(DEFAULT_VEIN_CHOPPER_TOOLS);
+    }
+
+    List<String> list = _fileConfig.getStringList(path);
+    return list == null ? new java.util.ArrayList<>() : new java.util.ArrayList<>(list);
   }
 
   public void setVeinChopperAllowedTools(List<String> tools) {
@@ -289,8 +322,13 @@ public class SettingsManager {
   }
 
   public List<String> getVeinChopperAllowedBlocks() {
-    List<String> list = _fileConfig.getStringList("global.veinchopper.allowedblocks");
-    return list == null || list.isEmpty() ? new java.util.ArrayList<>(DEFAULT_VEIN_CHOPPER_BLOCKS) : list;
+    String path = "global.veinchopper.allowedblocks";
+    if (!_fileConfig.contains(path)) {
+      return new java.util.ArrayList<>(DEFAULT_VEIN_CHOPPER_BLOCKS);
+    }
+
+    List<String> list = _fileConfig.getStringList(path);
+    return list == null ? new java.util.ArrayList<>() : new java.util.ArrayList<>(list);
   }
 
   public void setVeinChopperAllowedBlocks(List<String> blocks) {


### PR DESCRIPTION
## Summary
- add default lists and configuration getters for vein miner/chopper
- allow editing of material lists via `MaterialToggleGUI`
- add vein miner/chopper settings menus
- open these new menus from admin settings
- make vein mining/chopping event read values from config

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d3d9b0a883209d862c1192fade6a