### PR TITLE
Add sign color support

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -28,6 +28,7 @@ import com.daveestar.bettervanilla.events.VeinMiningChopping;
 import com.daveestar.bettervanilla.events.RightClickCropHarvest;
 import com.daveestar.bettervanilla.events.ChestSort;
 import com.daveestar.bettervanilla.events.CropProtection;
+import com.daveestar.bettervanilla.events.SignColors;
 import com.daveestar.bettervanilla.manager.AFKManager;
 import com.daveestar.bettervanilla.manager.CompassManager;
 import com.daveestar.bettervanilla.manager.DeathPointsManager;
@@ -122,6 +123,7 @@ public class Main extends JavaPlugin {
     manager.registerEvents(new RightClickCropHarvest(), this);
     manager.registerEvents(new ChestSort(), this);
     manager.registerEvents(new VeinMiningChopping(), this);
+    manager.registerEvents(new SignColors(), this);
   }
 
   @Override

--- a/src/main/java/com/daveestar/bettervanilla/events/SignColors.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/SignColors.java
@@ -1,0 +1,21 @@
+package com.daveestar.bettervanilla.events;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.SignChangeEvent;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+
+public class SignColors implements Listener {
+  @EventHandler
+  public void onSignChange(SignChangeEvent e) {
+    for (int i = 0; i < e.lines().size(); i++) {
+      Component current = e.line(i);
+      String raw = PlainTextComponentSerializer.plainText().serialize(current);
+      Component colored = LegacyComponentSerializer.legacyAmpersand().deserialize(raw);
+      e.line(i, colored);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- colorize sign text using `&` codes
- register new `SignColors` listener

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e951c7ee0832099c9cfc6db05cec8