### PR TITLE
Add private messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 📜 Changelog
 
+## [1.7.0] - Unreleased
+
+- **💬 Private Messages** – New `/msg` and `/r` commands for direct player chats.
+
 ## [1.6.0] - 16.07.2025
 
 - **🎒 Backpacks** – Portable storage with configurable pages and rows. Use `/backpack` anywhere.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Whether you’re spinning up a fresh community project or running a seasoned net
 - 📦 **Chest Sorting** – Right‑click outside a chest inventory to instantly sort it
 - 🛠️ **Settings Menu** – `/settings` player settings can be toggled from there
 - 🎨 **Colored Chat & Mentions** – Use `&` color codes and ping players with `@name`
+- 💬 **Private Messages** – Send direct messages with `/msg` and reply quickly with `/r`
 - 🔍 **Inventory Viewer** – Peek inside another player’s inventory
 - ⏲️ **Timer** – Global stopwatch with resume, pause, reset & set
 - ⏱️ **Playtime** – Track and display personal or global playtime, even for offline players

--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -17,6 +17,8 @@ import com.daveestar.bettervanilla.commands.ToggleCompassCommand;
 import com.daveestar.bettervanilla.commands.ToggleLocationCommand;
 import com.daveestar.bettervanilla.commands.WaypointsCommand;
 import com.daveestar.bettervanilla.commands.BackpackCommand;
+import com.daveestar.bettervanilla.commands.MsgCommand;
+import com.daveestar.bettervanilla.commands.ReplyCommand;
 import com.daveestar.bettervanilla.events.ChatMessages;
 import com.daveestar.bettervanilla.events.DeathChest;
 import com.daveestar.bettervanilla.events.PlayerMove;
@@ -39,6 +41,7 @@ import com.daveestar.bettervanilla.manager.SettingsManager;
 import com.daveestar.bettervanilla.manager.TimerManager;
 import com.daveestar.bettervanilla.manager.WaypointsManager;
 import com.daveestar.bettervanilla.manager.BackpackManager;
+import com.daveestar.bettervanilla.manager.MessageManager;
 import com.daveestar.bettervanilla.utils.ActionBar;
 import com.daveestar.bettervanilla.utils.Config;
 
@@ -62,6 +65,7 @@ public class Main extends JavaPlugin {
   private TimerManager _timerManager;
   private MaintenanceManager _maintenanceManager;
   private BackpackManager _backpackManager;
+  private MessageManager _messageManager;
 
   public void onEnable() {
     _mainInstance = this;
@@ -79,6 +83,7 @@ public class Main extends JavaPlugin {
     _deathPointManager = new DeathPointsManager(deathPointConfig);
     _waypointsManager = new WaypointsManager(waypointsConfig);
     _backpackManager = new BackpackManager(backpackConfig);
+    _messageManager = new MessageManager();
 
     _maintenanceManager = new MaintenanceManager();
     _actionBar = new ActionBar();
@@ -109,6 +114,8 @@ public class Main extends JavaPlugin {
     getCommand("settings").setExecutor(new SettingsCommand());
     getCommand("permissions").setExecutor(new PermissionsCommand());
     getCommand("backpack").setExecutor(new BackpackCommand());
+    getCommand("msg").setExecutor(new MsgCommand());
+    getCommand("r").setExecutor(new ReplyCommand());
 
     // register events
     PluginManager manager = getServer().getPluginManager();
@@ -195,5 +202,9 @@ public class Main extends JavaPlugin {
 
   public BackpackManager getBackpackManager() {
     return _backpackManager;
+  }
+
+  public MessageManager getMessageManager() {
+    return _messageManager;
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/commands/MsgCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/MsgCommand.java
@@ -1,0 +1,64 @@
+package com.daveestar.bettervanilla.commands;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.Arrays;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.MessageManager;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class MsgCommand implements TabExecutor {
+  private final Main _plugin;
+  private final MessageManager _messageManager;
+
+  public MsgCommand() {
+    _plugin = Main.getInstance();
+    _messageManager = _plugin.getMessageManager();
+  }
+
+  @Override
+  public boolean onCommand(CommandSender cs, Command c, String label, String[] args) {
+    if (cs instanceof Player) {
+      Player p = (Player) cs;
+
+      if (args.length >= 2) {
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target != null && target.isOnline()) {
+          String message = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
+          _messageManager.sendPrivateMessage(p, target, message);
+        } else {
+          p.sendMessage(Main.getPrefix() + ChatColor.RED + "The requested player " + ChatColor.YELLOW + args[0]
+              + ChatColor.RED + " is currently not online!");
+        }
+      } else {
+        p.sendMessage(Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/msg <player> <message>");
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public List<String> onTabComplete(CommandSender cs, Command c, String label, String[] args) {
+    List<String> suggestions = new ArrayList<>();
+
+    if (args.length == 1) {
+      Collection<? extends Player> onlinePlayers = _plugin.getServer().getOnlinePlayers();
+      suggestions.addAll(onlinePlayers.stream().map(Player::getName).collect(Collectors.toList()));
+    }
+
+    return suggestions;
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/commands/ReplyCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/ReplyCommand.java
@@ -1,0 +1,44 @@
+package com.daveestar.bettervanilla.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.MessageManager;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class ReplyCommand implements CommandExecutor {
+  private final Main _plugin;
+  private final MessageManager _messageManager;
+
+  public ReplyCommand() {
+    _plugin = Main.getInstance();
+    _messageManager = _plugin.getMessageManager();
+  }
+
+  @Override
+  public boolean onCommand(CommandSender cs, Command c, String label, String[] args) {
+    if (cs instanceof Player) {
+      Player p = (Player) cs;
+
+      if (args.length >= 1) {
+        Player target = _messageManager.getReplyTarget(p);
+        if (target != null) {
+          String message = String.join(" ", args);
+          _messageManager.sendPrivateMessage(p, target, message);
+        } else {
+          p.sendMessage(Main.getPrefix() + ChatColor.RED + "You have no one to reply to.");
+        }
+      } else {
+        p.sendMessage(Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/r <message>");
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/enums/Permissions.java
+++ b/src/main/java/com/daveestar/bettervanilla/enums/Permissions.java
@@ -18,7 +18,8 @@ public enum Permissions {
   LASTDEATH("bettervanilla.deathpoints"),
   PERMISSION("bettervanilla.permissions"),
   VEINMINER("bettervanilla.veinminer"),
-  VEINCHOPPER("bettervanilla.veinchopper");
+  VEINCHOPPER("bettervanilla.veinchopper"),
+  MSG("bettervanilla.msg");
 
   private final String _permission;
 

--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -15,6 +15,7 @@ import com.daveestar.bettervanilla.manager.MaintenanceManager;
 import com.daveestar.bettervanilla.manager.PermissionsManager;
 import com.daveestar.bettervanilla.manager.TimerManager;
 import com.daveestar.bettervanilla.manager.BackpackManager;
+import com.daveestar.bettervanilla.manager.MessageManager;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
@@ -30,6 +31,7 @@ public class ChatMessages implements Listener {
   private final CompassManager _compassManager;
   private final MaintenanceManager _maintenanceManager;
   private final BackpackManager _backpackManager;
+  private final MessageManager _messageManager;
 
   public ChatMessages() {
     _plugin = Main.getInstance();
@@ -39,6 +41,7 @@ public class ChatMessages implements Listener {
     _compassManager = _plugin.getCompassManager();
     _maintenanceManager = _plugin.getMaintenanceManager();
     _backpackManager = _plugin.getBackpackManager();
+    _messageManager = _plugin.getMessageManager();
   }
 
   @EventHandler
@@ -77,6 +80,7 @@ public class ChatMessages implements Listener {
     _timerManager.onPlayerLeft(p);
     _compassManager.onPlayerLeft(p);
     _backpackManager.onPlayerLeft(p);
+    _messageManager.onPlayerLeft(p);
   }
 
   @EventHandler
@@ -88,6 +92,7 @@ public class ChatMessages implements Listener {
     _timerManager.onPlayerLeft(p);
     _compassManager.onPlayerLeft(p);
     _backpackManager.onPlayerLeft(p);
+    _messageManager.onPlayerLeft(p);
   }
 
   @EventHandler

--- a/src/main/java/com/daveestar/bettervanilla/manager/MessageManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/MessageManager.java
@@ -1,0 +1,40 @@
+package com.daveestar.bettervanilla.manager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.entity.Player;
+
+import com.daveestar.bettervanilla.Main;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class MessageManager {
+  private final Main _plugin;
+  private final Map<Player, Player> _lastMessages = new HashMap<>();
+
+  public MessageManager() {
+    _plugin = Main.getInstance();
+  }
+
+  public void sendPrivateMessage(Player sender, Player receiver, String message) {
+    String translated = ChatColor.translateAlternateColorCodes('&', message);
+    sender.sendMessage(Main.getPrefix() + ChatColor.GRAY + "(to " + ChatColor.YELLOW + receiver.getName() + ChatColor.GRAY + ") " + translated);
+    receiver.sendMessage(Main.getPrefix() + ChatColor.GRAY + "(from " + ChatColor.YELLOW + sender.getName() + ChatColor.GRAY + ") " + translated);
+    _lastMessages.put(sender, receiver);
+    _lastMessages.put(receiver, sender);
+  }
+
+  public Player getReplyTarget(Player player) {
+    Player target = _lastMessages.get(player);
+    if (target != null && target.isOnline()) {
+      return target;
+    }
+    return null;
+  }
+
+  public void onPlayerLeft(Player player) {
+    _lastMessages.remove(player);
+    _lastMessages.entrySet().removeIf(entry -> entry.getValue().equals(player));
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/manager/MessageManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/MessageManager.java
@@ -19,8 +19,9 @@ public class MessageManager {
 
   public void sendPrivateMessage(Player sender, Player receiver, String message) {
     String translated = ChatColor.translateAlternateColorCodes('&', message);
-    sender.sendMessage(Main.getPrefix() + ChatColor.GRAY + "(to " + ChatColor.YELLOW + receiver.getName() + ChatColor.GRAY + ") " + translated);
-    receiver.sendMessage(Main.getPrefix() + ChatColor.GRAY + "(from " + ChatColor.YELLOW + sender.getName() + ChatColor.GRAY + ") " + translated);
+    String prefix = Main.getPrefix() + ChatColor.DARK_AQUA + "[PM] " + ChatColor.GRAY;
+    sender.sendMessage(prefix + ChatColor.YELLOW + "You -> " + receiver.getName() + ChatColor.GRAY + ": " + translated);
+    receiver.sendMessage(prefix + ChatColor.YELLOW + sender.getName() + ChatColor.GRAY + " -> You: " + translated);
     _lastMessages.put(sender, receiver);
     _lastMessages.put(receiver, sender);
   }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -63,3 +63,12 @@ commands:
     description: Open your backpack.
     usage: /backpack
     permission: bettervanilla.backpack
+  msg:
+    description: Send a private message to another player.
+    usage: /msg <player> <message>
+    permission: bettervanilla.msg
+  r:
+    aliases: [reply]
+    description: Reply to the last private message.
+    usage: /r <message>
+    permission: bettervanilla.msg


### PR DESCRIPTION
## Summary
- implement new `MessageManager` to track conversations
- add `/msg` and `/r` commands for private messaging
- register new commands and permission
- document feature in README and CHANGELOG

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9a9eb0948320ad66b0a42b72c1c4