### PR TITLE
Add vanish command

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -19,6 +19,7 @@ import com.daveestar.bettervanilla.commands.WaypointsCommand;
 import com.daveestar.bettervanilla.commands.BackpackCommand;
 import com.daveestar.bettervanilla.commands.MsgCommand;
 import com.daveestar.bettervanilla.commands.ReplyCommand;
+import com.daveestar.bettervanilla.commands.VanishCommand;
 import com.daveestar.bettervanilla.events.ChatMessages;
 import com.daveestar.bettervanilla.events.DeathChest;
 import com.daveestar.bettervanilla.events.PlayerMove;
@@ -31,6 +32,7 @@ import com.daveestar.bettervanilla.events.RightClickCropHarvest;
 import com.daveestar.bettervanilla.events.ChestSort;
 import com.daveestar.bettervanilla.events.CropProtection;
 import com.daveestar.bettervanilla.events.SignColors;
+import com.daveestar.bettervanilla.events.VanishEvents;
 import com.daveestar.bettervanilla.manager.AFKManager;
 import com.daveestar.bettervanilla.manager.CompassManager;
 import com.daveestar.bettervanilla.manager.DeathPointsManager;
@@ -42,6 +44,7 @@ import com.daveestar.bettervanilla.manager.TimerManager;
 import com.daveestar.bettervanilla.manager.WaypointsManager;
 import com.daveestar.bettervanilla.manager.BackpackManager;
 import com.daveestar.bettervanilla.manager.MessageManager;
+import com.daveestar.bettervanilla.manager.VanishManager;
 import com.daveestar.bettervanilla.utils.ActionBar;
 import com.daveestar.bettervanilla.utils.Config;
 
@@ -66,6 +69,7 @@ public class Main extends JavaPlugin {
   private MaintenanceManager _maintenanceManager;
   private BackpackManager _backpackManager;
   private MessageManager _messageManager;
+  private VanishManager _vanishManager;
 
   public void onEnable() {
     _mainInstance = this;
@@ -84,6 +88,8 @@ public class Main extends JavaPlugin {
     _waypointsManager = new WaypointsManager(waypointsConfig);
     _backpackManager = new BackpackManager(backpackConfig);
     _messageManager = new MessageManager();
+
+    _vanishManager = new VanishManager();
 
     _maintenanceManager = new MaintenanceManager();
     _actionBar = new ActionBar();
@@ -116,6 +122,7 @@ public class Main extends JavaPlugin {
     getCommand("backpack").setExecutor(new BackpackCommand());
     getCommand("message").setExecutor(new MsgCommand());
     getCommand("reply").setExecutor(new ReplyCommand());
+    getCommand("vanish").setExecutor(new VanishCommand());
 
     // register events
     PluginManager manager = getServer().getPluginManager();
@@ -131,6 +138,7 @@ public class Main extends JavaPlugin {
     manager.registerEvents(new ChestSort(), this);
     manager.registerEvents(new VeinMiningChopping(), this);
     manager.registerEvents(new SignColors(), this);
+    manager.registerEvents(new VanishEvents(), this);
   }
 
   @Override
@@ -206,5 +214,9 @@ public class Main extends JavaPlugin {
 
   public MessageManager getMessageManager() {
     return _messageManager;
+  }
+
+  public VanishManager getVanishManager() {
+    return _vanishManager;
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/commands/VanishCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/VanishCommand.java
@@ -1,0 +1,38 @@
+package com.daveestar.bettervanilla.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.VanishManager;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class VanishCommand implements CommandExecutor {
+  private final VanishManager _vanishManager;
+
+  public VanishCommand() {
+    _vanishManager = Main.getInstance().getVanishManager();
+  }
+
+  @Override
+  public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    if (!(sender instanceof Player)) {
+      return true;
+    }
+
+    Player p = (Player) sender;
+
+    if (_vanishManager.isVanished(p)) {
+      _vanishManager.unvanish(p);
+      p.sendMessage(Main.getPrefix() + ChatColor.YELLOW + "You are now visible.");
+    } else {
+      _vanishManager.vanish(p);
+      p.sendMessage(Main.getPrefix() + ChatColor.YELLOW + "You vanished.");
+    }
+
+    return true;
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/enums/Permissions.java
+++ b/src/main/java/com/daveestar/bettervanilla/enums/Permissions.java
@@ -19,7 +19,8 @@ public enum Permissions {
   PERMISSION("bettervanilla.permissions"),
   VEINMINER("bettervanilla.veinminer"),
   VEINCHOPPER("bettervanilla.veinchopper"),
-  MSG("bettervanilla.msg");
+  MSG("bettervanilla.msg"),
+  VANISH("bettervanilla.vanish");
 
   private final String _permission;
 

--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -16,6 +16,7 @@ import com.daveestar.bettervanilla.manager.PermissionsManager;
 import com.daveestar.bettervanilla.manager.TimerManager;
 import com.daveestar.bettervanilla.manager.BackpackManager;
 import com.daveestar.bettervanilla.manager.MessageManager;
+import com.daveestar.bettervanilla.manager.VanishManager;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
@@ -32,6 +33,7 @@ public class ChatMessages implements Listener {
   private final MaintenanceManager _maintenanceManager;
   private final BackpackManager _backpackManager;
   private final MessageManager _messageManager;
+  private final VanishManager _vanishManager;
 
   public ChatMessages() {
     _plugin = Main.getInstance();
@@ -42,6 +44,7 @@ public class ChatMessages implements Listener {
     _maintenanceManager = _plugin.getMaintenanceManager();
     _backpackManager = _plugin.getBackpackManager();
     _messageManager = _plugin.getMessageManager();
+    _vanishManager = _plugin.getVanishManager();
   }
 
   @EventHandler
@@ -49,6 +52,13 @@ public class ChatMessages implements Listener {
     Player p = (Player) e.getPlayer();
 
     _permissionsManager.onPlayerJoined(p);
+
+    _vanishManager.getVanishedPlayers().forEach(id -> {
+      Player vanished = _plugin.getServer().getPlayer(id);
+      if (vanished != null) {
+        p.hidePlayer(_plugin, vanished);
+      }
+    });
 
     if (_maintenanceManager.getState()) {
       boolean bypass = _maintenanceManager.sendMaintenance(p);
@@ -75,6 +85,8 @@ public class ChatMessages implements Listener {
     e.quitMessage(Component
         .text(ChatColor.GRAY + "[" + ChatColor.RED + "-" + ChatColor.GRAY + "] " + ChatColor.RED + p.getName()));
 
+    _vanishManager.onPlayerLeft(p);
+
     _permissionsManager.onPlayerLeft(p);
     _afkManager.onPlayerLeft(p);
     _timerManager.onPlayerLeft(p);
@@ -93,6 +105,7 @@ public class ChatMessages implements Listener {
     _compassManager.onPlayerLeft(p);
     _backpackManager.onPlayerLeft(p);
     _messageManager.onPlayerLeft(p);
+    _vanishManager.onPlayerLeft(p);
   }
 
   @EventHandler

--- a/src/main/java/com/daveestar/bettervanilla/events/VanishEvents.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/VanishEvents.java
@@ -1,0 +1,26 @@
+package com.daveestar.bettervanilla.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.VanishManager;
+
+public class VanishEvents implements Listener {
+  private final VanishManager _vanishManager;
+
+  public VanishEvents() {
+    _vanishManager = Main.getInstance().getVanishManager();
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onDamage(EntityDamageEvent e) {
+    if (e.getEntity() instanceof Player p) {
+      if (_vanishManager.isVanished(p)) {
+        e.setCancelled(true);
+      }
+    }
+  }
+}

--- a/src/main/java/com/daveestar/bettervanilla/manager/VanishManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/VanishManager.java
@@ -1,0 +1,72 @@
+package com.daveestar.bettervanilla.manager;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.bukkit.entity.Player;
+
+import com.daveestar.bettervanilla.Main;
+
+import net.kyori.adventure.text.Component;
+import net.md_5.bungee.api.ChatColor;
+
+public class VanishManager {
+  private final Main _plugin;
+  private final Set<UUID> _vanished = new HashSet<>();
+
+  public VanishManager() {
+    _plugin = Main.getInstance();
+  }
+
+  public void vanish(Player p) {
+    if (_vanished.contains(p.getUniqueId())) {
+      return;
+    }
+
+    _vanished.add(p.getUniqueId());
+    _plugin.getServer().getOnlinePlayers().forEach(pl -> {
+      if (!pl.equals(p)) {
+        pl.hidePlayer(_plugin, p);
+      }
+    });
+
+    p.setAllowFlight(true);
+    p.setFlying(true);
+    p.setInvulnerable(true);
+    p.setCollidable(false);
+    p.setInvisible(true);
+    p.playerListName(Component.empty());
+  }
+
+  public void unvanish(Player p) {
+    if (!_vanished.contains(p.getUniqueId())) {
+      return;
+    }
+
+    _vanished.remove(p.getUniqueId());
+    _plugin.getServer().getOnlinePlayers().forEach(pl -> {
+      if (!pl.equals(p)) {
+        pl.showPlayer(_plugin, p);
+      }
+    });
+
+    p.setInvisible(false);
+    p.setInvulnerable(false);
+    p.setCollidable(true);
+    p.setAllowFlight(false);
+    p.playerListName(Component.text(ChatColor.RED + " » " + ChatColor.YELLOW + p.getName()));
+  }
+
+  public boolean isVanished(Player p) {
+    return _vanished.contains(p.getUniqueId());
+  }
+
+  public void onPlayerLeft(Player p) {
+    _vanished.remove(p.getUniqueId());
+  }
+
+  public Set<UUID> getVanishedPlayers() {
+    return _vanished;
+  }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -73,3 +73,7 @@ commands:
     description: Reply to the last private message.
     usage: /r <message>
     permission: bettervanilla.msg
+  vanish:
+    description: Toggle vanish mode.
+    usage: /vanish
+    permission: bettervanilla.vanish


### PR DESCRIPTION
## Summary
- implement a new `vanish` admin command
- track vanished players with new `VanishManager`
- prevent damage while vanished with `VanishEvents`
- hide vanished players when others join
- register command and permission

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fdf63b7788320af03ba2dede85613