### PR TITLE
Enhance moderation commands

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -131,23 +131,18 @@ public class Main extends JavaPlugin {
     getCommand("vanish").setExecutor(new VanishCommand());
     ModerationCommands.KickCommand kick = new ModerationCommands.KickCommand();
     getCommand("kick").setExecutor(kick);
-    getCommand("kick").setTabCompleter(kick);
 
     ModerationCommands.BanCommand ban = new ModerationCommands.BanCommand();
     getCommand("ban").setExecutor(ban);
-    getCommand("ban").setTabCompleter(ban);
 
     ModerationCommands.UnbanCommand unban = new ModerationCommands.UnbanCommand();
     getCommand("unban").setExecutor(unban);
-    getCommand("unban").setTabCompleter(unban);
 
     ModerationCommands.MuteCommand mute = new ModerationCommands.MuteCommand();
     getCommand("mute").setExecutor(mute);
-    getCommand("mute").setTabCompleter(mute);
 
     ModerationCommands.UnmuteCommand unmute = new ModerationCommands.UnmuteCommand();
     getCommand("unmute").setExecutor(unmute);
-    getCommand("unmute").setTabCompleter(unmute);
 
     // register events
     PluginManager manager = getServer().getPluginManager();

--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -129,11 +129,25 @@ public class Main extends JavaPlugin {
     getCommand("message").setExecutor(new MsgCommand());
     getCommand("reply").setExecutor(new ReplyCommand());
     getCommand("vanish").setExecutor(new VanishCommand());
-    getCommand("kick").setExecutor(new ModerationCommands.KickCommand());
-    getCommand("ban").setExecutor(new ModerationCommands.BanCommand());
-    getCommand("unban").setExecutor(new ModerationCommands.UnbanCommand());
-    getCommand("mute").setExecutor(new ModerationCommands.MuteCommand());
-    getCommand("unmute").setExecutor(new ModerationCommands.UnmuteCommand());
+    ModerationCommands.KickCommand kick = new ModerationCommands.KickCommand();
+    getCommand("kick").setExecutor(kick);
+    getCommand("kick").setTabCompleter(kick);
+
+    ModerationCommands.BanCommand ban = new ModerationCommands.BanCommand();
+    getCommand("ban").setExecutor(ban);
+    getCommand("ban").setTabCompleter(ban);
+
+    ModerationCommands.UnbanCommand unban = new ModerationCommands.UnbanCommand();
+    getCommand("unban").setExecutor(unban);
+    getCommand("unban").setTabCompleter(unban);
+
+    ModerationCommands.MuteCommand mute = new ModerationCommands.MuteCommand();
+    getCommand("mute").setExecutor(mute);
+    getCommand("mute").setTabCompleter(mute);
+
+    ModerationCommands.UnmuteCommand unmute = new ModerationCommands.UnmuteCommand();
+    getCommand("unmute").setExecutor(unmute);
+    getCommand("unmute").setTabCompleter(unmute);
 
     // register events
     PluginManager manager = getServer().getPluginManager();

--- a/src/main/java/com/daveestar/bettervanilla/commands/HelpCommand.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/HelpCommand.java
@@ -63,6 +63,12 @@ public class HelpCommand implements CommandExecutor {
       Player p = (Player) cs;
 
       p.sendMessage(Main.getPrefix() + ChatColor.YELLOW + ChatColor.BOLD + "ADMIN COMMANDS:");
+      p.sendMessage(Main.getShortPrefix() + "/kick <player> [reason] - Kick a player from the server");
+      p.sendMessage(Main.getShortPrefix() + "/ban <player> [duration] [reason] - Ban a player from the server");
+      p.sendMessage(Main.getShortPrefix() + "/unban <player> - Remove a player's ban");
+      p.sendMessage(Main.getShortPrefix() + "/mute <player> [duration] [reason] - Mute a player");
+      p.sendMessage(Main.getShortPrefix() + "/unmute <player> - Remove a player's mute");
+      p.sendMessage("");
       p.sendMessage(Main.getShortPrefix() + "/waypoints remove <name> - Remove an existing waypoint");
       p.sendMessage("");
       p.sendMessage(Main.getShortPrefix() + "/timer resume - Resume the timer");

--- a/src/main/java/com/daveestar/bettervanilla/commands/ModerationCommands.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/ModerationCommands.java
@@ -137,11 +137,19 @@ public class ModerationCommands {
 
       if (durationSeconds > 0) {
         String time = _timerManager.formatTime((int) durationSeconds);
-        sender.sendMessage(Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY
-            + " has been temp-banned for " + ChatColor.YELLOW + time + ChatColor.GRAY + ".");
+        String confirm = Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY
+            + " has been temp-banned for " + ChatColor.YELLOW + time + ChatColor.GRAY + ".";
+        if (reason != null && !reason.isEmpty()) {
+          confirm += " Reason: " + ChatColor.YELLOW + reason;
+        }
+        sender.sendMessage(confirm);
       } else {
-        sender.sendMessage(Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY
-            + " has been banned.");
+        String confirm = Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY
+            + " has been banned.";
+        if (reason != null && !reason.isEmpty()) {
+          confirm += " Reason: " + ChatColor.YELLOW + reason;
+        }
+        sender.sendMessage(confirm);
       }
       return true;
     }
@@ -243,27 +251,33 @@ public class ModerationCommands {
       }
 
       if (target.isOnline()) {
-        String msg = Main.getPrefix() + ChatColor.RED + "You have been muted.";
+        String msg = Main.getPrefix() + ChatColor.RED + "You have been muted";
+        if (durationSeconds > 0) {
+          String time = _timerManager.formatTime((int) durationSeconds);
+          msg += ChatColor.GRAY + " for " + ChatColor.YELLOW + time;
+        }
+        msg += ChatColor.GRAY + ".";
         if (reason != null && !reason.isEmpty()) {
           msg += " Reason: " + ChatColor.YELLOW + reason;
         } else {
           msg += " No reason given.";
         }
-        if (durationSeconds > 0) {
-          String time = _timerManager.formatTime((int) durationSeconds);
-          msg += " Expires in: " + ChatColor.YELLOW + time;
-        }
         target.getPlayer().sendMessage(msg);
       }
 
+      String confirm =
+          Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " has been ";
       if (durationSeconds > 0) {
         String time = _timerManager.formatTime((int) durationSeconds);
-        sender.sendMessage(Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY
-            + " has been muted for " + ChatColor.YELLOW + time + ChatColor.GRAY + ".");
+        confirm += "muted for " + ChatColor.YELLOW + time + ChatColor.GRAY;
       } else {
-        sender.sendMessage(Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY
-            + " has been muted.");
+        confirm += "muted";
       }
+      confirm += ".";
+      if (reason != null && !reason.isEmpty()) {
+        confirm += " Reason: " + ChatColor.YELLOW + reason;
+      }
+      sender.sendMessage(confirm);
       return true;
     }
 
@@ -297,6 +311,9 @@ public class ModerationCommands {
 
       OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
       modManager.unmutePlayer(target);
+      if (target.isOnline()) {
+        target.getPlayer().sendMessage(Main.getPrefix() + ChatColor.GRAY + "You have been unmuted.");
+      }
       sender.sendMessage(
           Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " has been unmuted.");
       return true;

--- a/src/main/java/com/daveestar/bettervanilla/commands/ModerationCommands.java
+++ b/src/main/java/com/daveestar/bettervanilla/commands/ModerationCommands.java
@@ -1,15 +1,20 @@
 package com.daveestar.bettervanilla.commands;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
 
 import com.daveestar.bettervanilla.Main;
 import com.daveestar.bettervanilla.manager.ModerationManager;
@@ -19,7 +24,7 @@ import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.ChatColor;
 
 public class ModerationCommands {
-  public static class KickCommand implements CommandExecutor {
+  public static class KickCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
       if (args.length < 1) {
@@ -34,24 +39,41 @@ public class ModerationCommands {
         return true;
       }
 
+      if (sender instanceof Player && target.getUniqueId().equals(((Player) sender).getUniqueId())) {
+        sender.sendMessage(Main.getPrefix() + ChatColor.RED + "You cannot kick yourself.");
+        return true;
+      }
+
       String reason = null;
       if (args.length > 1) {
         reason = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
       }
 
-      String kickMsg = ChatColor.YELLOW.toString() + ChatColor.BOLD.toString() + "KICKED\n\n"
-          + ChatColor.GRAY
+      String kickMsg = ChatColor.YELLOW.toString() + ChatColor.BOLD.toString() + "KICKED\n\n" + ChatColor.GRAY
           + "You were kicked from the server.\n\n"
-          + (reason != null ? ChatColor.YELLOW + "" + ChatColor.BOLD + "Reason: " + ChatColor.GRAY + reason
-              : "");
+          + (reason != null ? ChatColor.YELLOW + "" + ChatColor.BOLD + "Reason: " + ChatColor.GRAY + reason : "");
 
       target.kick(Component.text(kickMsg));
       sender.sendMessage(Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " has been kicked.");
       return true;
     }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+      if (args.length == 1) {
+        List<String> names = Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList());
+        if (sender instanceof Player) {
+          names.remove(((Player) sender).getName());
+        }
+        List<String> completions = new ArrayList<>();
+        StringUtil.copyPartialMatches(args[0], names, completions);
+        return completions;
+      }
+      return Collections.emptyList();
+    }
   }
 
-  public static class BanCommand implements CommandExecutor {
+  public static class BanCommand implements TabExecutor {
     private final ModerationManager _moderationManager;
     private final TimerManager _timerManager;
 
@@ -71,12 +93,16 @@ public class ModerationCommands {
       }
 
       OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
+      if (sender instanceof Player && target.getUniqueId().equals(((Player) sender).getUniqueId())) {
+        sender.sendMessage(Main.getPrefix() + ChatColor.RED + "You cannot ban yourself.");
+        return true;
+      }
 
       long durationSeconds = -1;
       String reason = null;
 
       if (args.length > 1) {
-        long parsed = _parseDuration(args[1]);
+        long parsed = parseDuration(args[1]);
         if (parsed > 0) {
           durationSeconds = parsed;
           if (args.length > 2) {
@@ -120,36 +146,21 @@ public class ModerationCommands {
       return true;
     }
 
-    private long _parseDuration(String input) {
-      Matcher matcher = Pattern.compile("(\\d+)([dhms])", Pattern.CASE_INSENSITIVE).matcher(input);
-      long total = 0;
-      int matched = 0;
-      while (matcher.find()) {
-        long value = Long.parseLong(matcher.group(1));
-        matched += matcher.group().length();
-        switch (matcher.group(2).toLowerCase()) {
-          case "d":
-            total += value * 86400;
-            break;
-          case "h":
-            total += value * 3600;
-            break;
-          case "m":
-            total += value * 60;
-            break;
-          case "s":
-            total += value;
-            break;
-          default:
-            return -1;
-        }
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+      if (args.length == 1) {
+        List<String> names = Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList());
+        if (sender instanceof Player) names.remove(((Player) sender).getName());
+        List<String> completions = new ArrayList<>();
+        StringUtil.copyPartialMatches(args[0], names, completions);
+        return completions;
       }
-      return matched == input.length() ? total : -1;
+      return Collections.emptyList();
     }
   }
 
   /** Remove a ban from a player. */
-  public static class UnbanCommand implements CommandExecutor {
+  public static class UnbanCommand implements TabExecutor {
     private final ModerationManager modManager;
 
     public UnbanCommand() {
@@ -164,15 +175,30 @@ public class ModerationCommands {
       }
 
       OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
+      if (!modManager.isBanned(target)) {
+        sender.sendMessage(Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " is not banned.");
+        return true;
+      }
       modManager.unbanPlayer(target);
-      sender
-          .sendMessage(Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " has been unbanned.");
+      sender.sendMessage(
+          Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " has been unbanned.");
       return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+      if (args.length == 1) {
+        List<String> names = modManager.getBannedPlayerNames();
+        List<String> completions = new ArrayList<>();
+        StringUtil.copyPartialMatches(args[0], names, completions);
+        return completions;
+      }
+      return Collections.emptyList();
     }
   }
 
   /** Mute or temp-mute a player. */
-  public static class MuteCommand implements CommandExecutor {
+  public static class MuteCommand implements TabExecutor {
     private final ModerationManager modManager;
     private final TimerManager _timerManager;
 
@@ -185,35 +211,53 @@ public class ModerationCommands {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
       if (args.length < 1) {
         sender.sendMessage(
-            Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/mute <player> [reason] [seconds]");
+            Main.getPrefix() + ChatColor.RED + "Usage: " + ChatColor.YELLOW + "/mute <player> [duration] [reason]");
         return true;
       }
 
       OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
-      long duration = -1;
-      String reason = "Muted";
+      if (sender instanceof Player && target.getUniqueId().equals(((Player) sender).getUniqueId())) {
+        sender.sendMessage(Main.getPrefix() + ChatColor.RED + "You cannot mute yourself.");
+        return true;
+      }
+
+      long durationSeconds = -1;
+      String reason = null;
 
       if (args.length > 1) {
-        reason = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
-        if (args.length > 2) {
-          String last = args[args.length - 1];
-          try {
-            duration = Long.parseLong(last);
-            reason = String.join(" ", Arrays.copyOfRange(args, 1, args.length - 1));
-          } catch (NumberFormatException ignore) {
-            duration = -1;
+        long parsed = parseDuration(args[1]);
+        if (parsed > 0) {
+          durationSeconds = parsed;
+          if (args.length > 2) {
+            reason = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
           }
+        } else {
+          reason = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
         }
       }
 
-      if (duration > 0) {
-        modManager.tempMutePlayer(target, reason, duration * 1000);
+      if (durationSeconds > 0) {
+        modManager.tempMutePlayer(target, reason, durationSeconds * 1000);
       } else {
         modManager.mutePlayer(target, reason);
       }
 
-      if (duration > 0) {
-        String time = _timerManager.formatTime((int) duration);
+      if (target.isOnline()) {
+        String msg = Main.getPrefix() + ChatColor.RED + "You have been muted.";
+        if (reason != null && !reason.isEmpty()) {
+          msg += " Reason: " + ChatColor.YELLOW + reason;
+        } else {
+          msg += " No reason given.";
+        }
+        if (durationSeconds > 0) {
+          String time = _timerManager.formatTime((int) durationSeconds);
+          msg += " Expires in: " + ChatColor.YELLOW + time;
+        }
+        target.getPlayer().sendMessage(msg);
+      }
+
+      if (durationSeconds > 0) {
+        String time = _timerManager.formatTime((int) durationSeconds);
         sender.sendMessage(Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY
             + " has been muted for " + ChatColor.YELLOW + time + ChatColor.GRAY + ".");
       } else {
@@ -222,10 +266,22 @@ public class ModerationCommands {
       }
       return true;
     }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+      if (args.length == 1) {
+        List<String> names = Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList());
+        if (sender instanceof Player) names.remove(((Player) sender).getName());
+        List<String> completions = new ArrayList<>();
+        StringUtil.copyPartialMatches(args[0], names, completions);
+        return completions;
+      }
+      return Collections.emptyList();
+    }
   }
 
   /** Remove a mute from a player. */
-  public static class UnmuteCommand implements CommandExecutor {
+  public static class UnmuteCommand implements TabExecutor {
     private final ModerationManager modManager;
 
     public UnmuteCommand() {
@@ -241,9 +297,47 @@ public class ModerationCommands {
 
       OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
       modManager.unmutePlayer(target);
-      sender
-          .sendMessage(Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " has been unmuted.");
+      sender.sendMessage(
+          Main.getPrefix() + ChatColor.YELLOW + target.getName() + ChatColor.GRAY + " has been unmuted.");
       return true;
     }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+      if (args.length == 1) {
+        List<String> names = modManager.getMutedPlayerNames();
+        List<String> completions = new ArrayList<>();
+        StringUtil.copyPartialMatches(args[0], names, completions);
+        return completions;
+      }
+      return Collections.emptyList();
+    }
+  }
+
+  static long parseDuration(String input) {
+    Matcher matcher = Pattern.compile("(\\d+)([dhms])", Pattern.CASE_INSENSITIVE).matcher(input);
+    long total = 0;
+    int matched = 0;
+    while (matcher.find()) {
+      long value = Long.parseLong(matcher.group(1));
+      matched += matcher.group().length();
+      switch (matcher.group(2).toLowerCase()) {
+        case "d":
+          total += value * 86400;
+          break;
+        case "h":
+          total += value * 3600;
+          break;
+        case "m":
+          total += value * 60;
+          break;
+        case "s":
+          total += value;
+          break;
+        default:
+          return -1;
+      }
+    }
+    return matched == input.length() ? total : -1;
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/events/ModerationEvents.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ModerationEvents.java
@@ -10,15 +10,18 @@ import org.bukkit.entity.Player;
 
 import com.daveestar.bettervanilla.Main;
 import com.daveestar.bettervanilla.manager.ModerationManager;
+import com.daveestar.bettervanilla.manager.TimerManager;
 
 import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.ChatColor;
 
 public class ModerationEvents implements Listener {
   private final ModerationManager _modManager;
+  private final TimerManager _timerManager;
 
   public ModerationEvents() {
     _modManager = Main.getInstance().getModerationManager();
+    _timerManager = Main.getInstance().getTimerManager();
   }
 
   @EventHandler
@@ -27,13 +30,17 @@ public class ModerationEvents implements Listener {
     if (_modManager.isBanned(p)) {
       String reason = _modManager.getBanReason(p);
       long expires = _modManager.getBanExpiry(p);
-      String msg = ChatColor.GRAY + "[" + ChatColor.YELLOW + "BetterVanilla" + ChatColor.GRAY + "] " + ChatColor.RED + "You are banned!";
-      if (!reason.isEmpty()) msg += "\n" + ChatColor.GRAY + "Reason: " + ChatColor.YELLOW + reason;
+      String banMsg = ChatColor.YELLOW + "" + ChatColor.BOLD + "BANNED\n\n" + ChatColor.GRAY
+          + "You were banned from the server.\n\n";
+      if (!reason.isEmpty()) {
+        banMsg += ChatColor.YELLOW + "" + ChatColor.BOLD + "Reason: " + ChatColor.GRAY + reason + "\n";
+      }
       if (expires != -1) {
         long remaining = (expires - System.currentTimeMillis()) / 1000;
-        msg += "\n" + ChatColor.GRAY + "Expires in: " + ChatColor.YELLOW + remaining + "s";
+        String time = _timerManager.formatTime((int) remaining);
+        banMsg += ChatColor.YELLOW + "" + ChatColor.BOLD + "Expires in: " + ChatColor.GRAY + time;
       }
-      e.disallow(AsyncPlayerPreLoginEvent.Result.KICK_BANNED, Component.text(msg));
+      e.disallow(AsyncPlayerPreLoginEvent.Result.KICK_BANNED, Component.text(banMsg));
     }
   }
 
@@ -42,7 +49,13 @@ public class ModerationEvents implements Listener {
     Player p = e.getPlayer();
     if (_modManager.isMuted(p)) {
       String reason = _modManager.getMuteReason(p);
-      p.sendMessage(Main.getPrefix() + ChatColor.RED + "You are muted." + (reason.isEmpty() ? "" : " Reason: " + ChatColor.YELLOW + reason));
+      String msg = Main.getPrefix() + ChatColor.RED + "You are muted.";
+      if (reason != null && !reason.isEmpty()) {
+        msg += " Reason: " + ChatColor.YELLOW + reason;
+      } else {
+        msg += " No reason given.";
+      }
+      p.sendMessage(msg);
       e.setCancelled(true);
     }
   }

--- a/src/main/java/com/daveestar/bettervanilla/events/ModerationEvents.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ModerationEvents.java
@@ -49,11 +49,17 @@ public class ModerationEvents implements Listener {
     Player p = e.getPlayer();
     if (_modManager.isMuted(p)) {
       String reason = _modManager.getMuteReason(p);
-      String msg = Main.getPrefix() + ChatColor.RED + "You are muted.";
+      long expires = _modManager.getMuteExpiry(p);
+      String msg = Main.getPrefix() + ChatColor.RED + "You are muted";
+      if (expires != -1) {
+        long remaining = (expires - System.currentTimeMillis()) / 1000;
+        String time = _timerManager.formatTime((int) remaining);
+        msg += ChatColor.GRAY + " for " + ChatColor.YELLOW + time;
+      }
       if (reason != null && !reason.isEmpty()) {
-        msg += " Reason: " + ChatColor.YELLOW + reason;
+        msg += ChatColor.GRAY + ". Reason: " + ChatColor.YELLOW + reason;
       } else {
-        msg += " No reason given.";
+        msg += ChatColor.GRAY + ". No reason given.";
       }
       p.sendMessage(msg);
       e.setCancelled(true);

--- a/src/main/java/com/daveestar/bettervanilla/manager/ModerationManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/ModerationManager.java
@@ -1,6 +1,13 @@
 package com.daveestar.bettervanilla.manager;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import com.daveestar.bettervanilla.utils.Config;
@@ -65,6 +72,17 @@ public class ModerationManager {
     return _fileConfig.getLong("bans." + p.getUniqueId() + ".expires", -1);
   }
 
+  public List<String> getBannedPlayerNames() {
+    ConfigurationSection section = _fileConfig.getConfigurationSection("bans");
+    if (section == null) return Collections.emptyList();
+    List<String> names = new ArrayList<>();
+    for (String key : section.getKeys(false)) {
+      OfflinePlayer p = Bukkit.getOfflinePlayer(UUID.fromString(key));
+      if (p.getName() != null) names.add(p.getName());
+    }
+    return names;
+  }
+
   public void mutePlayer(OfflinePlayer p, String reason) {
     mutePlayer(p, reason, -1);
   }
@@ -105,5 +123,16 @@ public class ModerationManager {
 
   public long getMuteExpiry(OfflinePlayer p) {
     return _fileConfig.getLong("mutes." + p.getUniqueId() + ".expires", -1);
+  }
+
+  public List<String> getMutedPlayerNames() {
+    ConfigurationSection section = _fileConfig.getConfigurationSection("mutes");
+    if (section == null) return Collections.emptyList();
+    List<String> names = new ArrayList<>();
+    for (String key : section.getKeys(false)) {
+      OfflinePlayer p = Bukkit.getOfflinePlayer(UUID.fromString(key));
+      if (p.getName() != null) names.add(p.getName());
+    }
+    return names;
   }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -83,7 +83,7 @@ commands:
     permission: bettervanilla.kick
   ban:
     description: Ban a player from the server.
-    usage: /ban <player> [reason] [seconds]
+    usage: /ban <player> [duration] [reason]
     permission: bettervanilla.ban
   unban:
     description: Remove a player's ban.
@@ -91,7 +91,7 @@ commands:
     permission: bettervanilla.unban
   mute:
     description: Mute a player.
-    usage: /mute <player> [reason] [seconds]
+    usage: /mute <player> [duration] [reason]
     permission: bettervanilla.mute
   unmute:
     description: Remove a player's mute.


### PR DESCRIPTION
## Summary
- Parse complex duration strings for /ban and present human-friendly expiry messages
- Improve ban kick message styling and display ban durations using TimerManager
- Format mute durations with TimerManager for clearer feedback

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d31b21e448320a5fb127f21c2aa06