### PR TITLE
feat: add player heart display setting

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -48,6 +48,7 @@ import com.daveestar.bettervanilla.manager.BackpackManager;
 import com.daveestar.bettervanilla.manager.MessageManager;
 import com.daveestar.bettervanilla.manager.VanishManager;
 import com.daveestar.bettervanilla.manager.ModerationManager;
+import com.daveestar.bettervanilla.manager.HealthDisplayManager;
 import com.daveestar.bettervanilla.utils.ActionBar;
 import com.daveestar.bettervanilla.utils.Config;
 
@@ -74,6 +75,7 @@ public class Main extends JavaPlugin {
   private MessageManager _messageManager;
   private VanishManager _vanishManager;
   private ModerationManager _moderationManager;
+  private HealthDisplayManager _healthDisplayManager;
 
   public void onEnable() {
     _mainInstance = this;
@@ -102,6 +104,7 @@ public class Main extends JavaPlugin {
     _navigationManager = new NavigationManager();
     _afkManager = new AFKManager();
     _compassManager = new CompassManager();
+    _healthDisplayManager = new HealthDisplayManager();
 
     // initialize managers with dependencies
     _afkManager.initManagers();
@@ -162,6 +165,7 @@ public class Main extends JavaPlugin {
     getServer().getOnlinePlayers().forEach(_timerManager::onPlayerLeft);
     _compassManager.destroy();
     _backpackManager.saveAllOpenBackpacks();
+    _healthDisplayManager.disable();
 
     _LOGGER.info("BetterVanilla - DISABLED");
   }
@@ -234,5 +238,9 @@ public class Main extends JavaPlugin {
 
   public ModerationManager getModerationManager() {
     return _moderationManager;
+  }
+
+  public HealthDisplayManager getHealthDisplayManager() {
+    return _healthDisplayManager;
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -17,6 +17,7 @@ import com.daveestar.bettervanilla.manager.TimerManager;
 import com.daveestar.bettervanilla.manager.BackpackManager;
 import com.daveestar.bettervanilla.manager.MessageManager;
 import com.daveestar.bettervanilla.manager.VanishManager;
+import com.daveestar.bettervanilla.manager.HealthDisplayManager;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
@@ -34,6 +35,7 @@ public class ChatMessages implements Listener {
   private final BackpackManager _backpackManager;
   private final MessageManager _messageManager;
   private final VanishManager _vanishManager;
+  private final HealthDisplayManager _healthDisplayManager;
 
   public ChatMessages() {
     _plugin = Main.getInstance();
@@ -45,6 +47,7 @@ public class ChatMessages implements Listener {
     _backpackManager = _plugin.getBackpackManager();
     _messageManager = _plugin.getMessageManager();
     _vanishManager = _plugin.getVanishManager();
+    _healthDisplayManager = _plugin.getHealthDisplayManager();
   }
 
   @EventHandler
@@ -69,6 +72,7 @@ public class ChatMessages implements Listener {
     _afkManager.onPlayerJoined(p);
     _timerManager.onPlayerJoined(p);
     _compassManager.onPlayerJoined(p);
+    _healthDisplayManager.onPlayerJoin(p);
   }
 
   @EventHandler

--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -72,7 +72,7 @@ public class ChatMessages implements Listener {
     _afkManager.onPlayerJoined(p);
     _timerManager.onPlayerJoined(p);
     _compassManager.onPlayerJoined(p);
-    _healthDisplayManager.onPlayerJoin(p);
+    _healthDisplayManager.onPlayerJoined(p);
   }
 
   @EventHandler

--- a/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
@@ -647,7 +647,7 @@ public class AdminSettingsGUI implements Listener {
   private void _toggleDisplayHearts(Player p) {
     boolean newState = !_settingsManager.getHealthDisplay();
     _settingsManager.setHealthDisplay(newState);
-    _healthDisplayManager.applySettingToAllPlayers();
+    _healthDisplayManager.applyHealthDisplaySetting();
     String stateText = newState ? "ENABLED" : "DISABLED";
     p.sendMessage(
         Main.getPrefix() + "Player hearts display is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);

--- a/src/main/java/com/daveestar/bettervanilla/manager/HealthDisplayManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/HealthDisplayManager.java
@@ -19,15 +19,15 @@ public class HealthDisplayManager {
     _settingsManager = Main.getInstance().getSettingsManager();
   }
 
-  public void applySettingToAllPlayers() {
+  public void applyHealthDisplaySetting() {
     if (_settingsManager.getHealthDisplay()) {
-      enable();
+      enableHealthDisplay();
     } else {
-      disable();
+      disableHealthDisplay();
     }
   }
 
-  public void enable() {
+  public void enableHealthDisplay() {
     ScoreboardManager manager = Bukkit.getScoreboardManager();
     if (manager == null) {
       return;
@@ -40,7 +40,7 @@ public class HealthDisplayManager {
     obj.setDisplaySlot(DisplaySlot.BELOW_NAME);
   }
 
-  public void disable() {
+  public void disableHealthDisplay() {
     ScoreboardManager manager = Bukkit.getScoreboardManager();
     if (manager == null) {
       return;
@@ -52,7 +52,7 @@ public class HealthDisplayManager {
     }
   }
 
-  public void onPlayerJoin(Player player) {
+  public void onPlayerJoined(Player player) {
     if (!_settingsManager.getHealthDisplay()) {
       return;
     }

--- a/src/main/java/com/daveestar/bettervanilla/manager/HealthDisplayManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/HealthDisplayManager.java
@@ -1,0 +1,70 @@
+package com.daveestar.bettervanilla.manager;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Criteria;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.ScoreboardManager;
+
+import com.daveestar.bettervanilla.Main;
+
+import net.kyori.adventure.text.Component;
+
+public class HealthDisplayManager {
+  private final SettingsManager _settingsManager;
+
+  public HealthDisplayManager() {
+    _settingsManager = Main.getInstance().getSettingsManager();
+  }
+
+  public void applySettingToAllPlayers() {
+    if (_settingsManager.getHealthDisplay()) {
+      enable();
+    } else {
+      disable();
+    }
+  }
+
+  public void enable() {
+    ScoreboardManager manager = Bukkit.getScoreboardManager();
+    if (manager == null) {
+      return;
+    }
+    Scoreboard board = manager.getMainScoreboard();
+    Objective obj = board.getObjective("bv_health");
+    if (obj == null) {
+      obj = board.registerNewObjective("bv_health", Criteria.HEALTH, Component.text("Health"));
+    }
+    obj.setDisplaySlot(DisplaySlot.BELOW_NAME);
+  }
+
+  public void disable() {
+    ScoreboardManager manager = Bukkit.getScoreboardManager();
+    if (manager == null) {
+      return;
+    }
+    Scoreboard board = manager.getMainScoreboard();
+    Objective obj = board.getObjective("bv_health");
+    if (obj != null) {
+      obj.unregister();
+    }
+  }
+
+  public void onPlayerJoin(Player player) {
+    if (!_settingsManager.getHealthDisplay()) {
+      return;
+    }
+    ScoreboardManager manager = Bukkit.getScoreboardManager();
+    if (manager == null) {
+      return;
+    }
+    Scoreboard board = manager.getMainScoreboard();
+    Objective obj = board.getObjective("bv_health");
+    if (obj != null) {
+      player.setScoreboard(board);
+    }
+  }
+}
+

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -202,6 +202,15 @@ public class SettingsManager {
     _config.save();
   }
 
+  public boolean getHealthDisplay() {
+    return _fileConfig.getBoolean("global.healthdisplay", false);
+  }
+
+  public void setHealthDisplay(boolean value) {
+    _fileConfig.set("global.healthdisplay", value);
+    _config.save();
+  }
+
   public boolean getBackpackEnabled() {
     return _fileConfig.getBoolean("global.backpack.enabled", false);
   }


### PR DESCRIPTION
## Summary
- allow admins to toggle displaying player hearts above names
- register hearts display during player join via chat events
- show hearts using scoreboard health objective in half-heart increments

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d46c77aa48320b1dfa77ea49b79b6