### PR TITLE
feat: display health under player nametags

### DIFF
--- a/src/main/java/com/daveestar/bettervanilla/Main.java
+++ b/src/main/java/com/daveestar/bettervanilla/Main.java
@@ -35,6 +35,7 @@ import com.daveestar.bettervanilla.events.CropProtection;
 import com.daveestar.bettervanilla.events.SignColors;
 import com.daveestar.bettervanilla.events.VanishEvents;
 import com.daveestar.bettervanilla.events.ModerationEvents;
+import com.daveestar.bettervanilla.events.HealthDisplayEvents;
 import com.daveestar.bettervanilla.manager.AFKManager;
 import com.daveestar.bettervanilla.manager.CompassManager;
 import com.daveestar.bettervanilla.manager.DeathPointsManager;
@@ -48,6 +49,7 @@ import com.daveestar.bettervanilla.manager.BackpackManager;
 import com.daveestar.bettervanilla.manager.MessageManager;
 import com.daveestar.bettervanilla.manager.VanishManager;
 import com.daveestar.bettervanilla.manager.ModerationManager;
+import com.daveestar.bettervanilla.manager.HealthDisplayManager;
 import com.daveestar.bettervanilla.utils.ActionBar;
 import com.daveestar.bettervanilla.utils.Config;
 
@@ -74,6 +76,7 @@ public class Main extends JavaPlugin {
   private MessageManager _messageManager;
   private VanishManager _vanishManager;
   private ModerationManager _moderationManager;
+  private HealthDisplayManager _healthDisplayManager;
 
   public void onEnable() {
     _mainInstance = this;
@@ -102,10 +105,12 @@ public class Main extends JavaPlugin {
     _navigationManager = new NavigationManager();
     _afkManager = new AFKManager();
     _compassManager = new CompassManager();
+    _healthDisplayManager = new HealthDisplayManager();
 
     // initialize managers with dependencies
     _afkManager.initManagers();
     _compassManager.initManagers();
+    _healthDisplayManager.initManagers();
     _maintenanceManager.initManagers();
     _navigationManager.initManagers();
     _timerManager.initManagers();
@@ -151,6 +156,7 @@ public class Main extends JavaPlugin {
     manager.registerEvents(new SignColors(), this);
     manager.registerEvents(new VanishEvents(), this);
     manager.registerEvents(new ModerationEvents(), this);
+    manager.registerEvents(new HealthDisplayEvents(), this);
   }
 
   @Override
@@ -161,6 +167,7 @@ public class Main extends JavaPlugin {
     _timerManager.setRunning(false);
     getServer().getOnlinePlayers().forEach(_timerManager::onPlayerLeft);
     _compassManager.destroy();
+    _healthDisplayManager.destroy();
     _backpackManager.saveAllOpenBackpacks();
 
     _LOGGER.info("BetterVanilla - DISABLED");
@@ -234,5 +241,9 @@ public class Main extends JavaPlugin {
 
   public ModerationManager getModerationManager() {
     return _moderationManager;
+  }
+
+  public HealthDisplayManager getHealthDisplayManager() {
+    return _healthDisplayManager;
   }
 }

--- a/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/ChatMessages.java
@@ -17,6 +17,7 @@ import com.daveestar.bettervanilla.manager.TimerManager;
 import com.daveestar.bettervanilla.manager.BackpackManager;
 import com.daveestar.bettervanilla.manager.MessageManager;
 import com.daveestar.bettervanilla.manager.VanishManager;
+import com.daveestar.bettervanilla.manager.HealthDisplayManager;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
@@ -34,6 +35,7 @@ public class ChatMessages implements Listener {
   private final BackpackManager _backpackManager;
   private final MessageManager _messageManager;
   private final VanishManager _vanishManager;
+  private final HealthDisplayManager _healthDisplayManager;
 
   public ChatMessages() {
     _plugin = Main.getInstance();
@@ -45,6 +47,7 @@ public class ChatMessages implements Listener {
     _backpackManager = _plugin.getBackpackManager();
     _messageManager = _plugin.getMessageManager();
     _vanishManager = _plugin.getVanishManager();
+    _healthDisplayManager = _plugin.getHealthDisplayManager();
   }
 
   @EventHandler
@@ -69,6 +72,7 @@ public class ChatMessages implements Listener {
     _afkManager.onPlayerJoined(p);
     _timerManager.onPlayerJoined(p);
     _compassManager.onPlayerJoined(p);
+    _healthDisplayManager.onPlayerJoined(p);
   }
 
   @EventHandler
@@ -85,6 +89,7 @@ public class ChatMessages implements Listener {
     _compassManager.onPlayerLeft(p);
     _backpackManager.onPlayerLeft(p);
     _messageManager.onPlayerLeft(p);
+    _healthDisplayManager.onPlayerLeft(p);
   }
 
   @EventHandler
@@ -98,6 +103,7 @@ public class ChatMessages implements Listener {
     _backpackManager.onPlayerLeft(p);
     _messageManager.onPlayerLeft(p);
     _vanishManager.onPlayerLeft(p);
+    _healthDisplayManager.onPlayerLeft(p);
   }
 
   @EventHandler

--- a/src/main/java/com/daveestar/bettervanilla/events/HealthDisplayEvents.java
+++ b/src/main/java/com/daveestar/bettervanilla/events/HealthDisplayEvents.java
@@ -1,0 +1,57 @@
+package com.daveestar.bettervanilla.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
+import org.bukkit.event.player.PlayerGameModeChangeEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.HealthDisplayManager;
+
+public class HealthDisplayEvents implements Listener {
+  private final HealthDisplayManager _manager;
+
+  public HealthDisplayEvents() {
+    _manager = Main.getInstance().getHealthDisplayManager();
+  }
+
+  @EventHandler
+  public void onDamage(EntityDamageEvent e) {
+    if (e.getEntity() instanceof Player p) {
+      _manager.onHealthChange(p);
+    }
+  }
+
+  @EventHandler
+  public void onRegain(EntityRegainHealthEvent e) {
+    if (e.getEntity() instanceof Player p) {
+      _manager.onHealthChange(p);
+    }
+  }
+
+  @EventHandler
+  public void onSneak(PlayerToggleSneakEvent e) {
+    _manager.onSneak(e.getPlayer(), e.isSneaking());
+  }
+
+  @EventHandler
+  public void onGameMode(PlayerGameModeChangeEvent e) {
+    _manager.onGameModeChange(e.getPlayer(), e.getNewGameMode());
+  }
+
+  @EventHandler
+  public void onRespawn(PlayerRespawnEvent e) {
+    _manager.onRespawn(e.getPlayer());
+  }
+
+  @EventHandler
+  public void onWorldChange(PlayerChangedWorldEvent e) {
+    _manager.onWorldChange(e.getPlayer());
+  }
+}
+

--- a/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
+++ b/src/main/java/com/daveestar/bettervanilla/gui/AdminSettingsGUI.java
@@ -72,6 +72,7 @@ public class AdminSettingsGUI implements Listener {
     // third row
     entries.put("cropprotection", _createCropProtectionItem());
     entries.put("rightclickcropharvest", _createRightClickCropHarvestItem());
+    entries.put("nametaghealth", _createNametagHealthItem());
     entries.put("veinminersettings", _createVeinMinerSettingsItem());
     entries.put("veinchoppersettings", _createVeinChopperSettingsItem());
 
@@ -92,6 +93,7 @@ public class AdminSettingsGUI implements Listener {
     // third row
     customSlots.put("cropprotection", 18);
     customSlots.put("rightclickcropharvest", 20);
+    customSlots.put("nametaghealth", 22);
     customSlots.put("veinminersettings", 24);
     customSlots.put("veinchoppersettings", 26);
 
@@ -165,6 +167,14 @@ public class AdminSettingsGUI implements Listener {
       @Override
       public void onLeftClick(Player p) {
         _toggleRightClickCropHarvest(p);
+        displayGUI(p, parentMenu);
+      }
+    });
+
+    actions.put("nametaghealth", new CustomGUI.ClickAction() {
+      @Override
+      public void onLeftClick(Player p) {
+        _toggleNametagHealth(p);
         displayGUI(p, parentMenu);
       }
     });
@@ -358,6 +368,27 @@ public class AdminSettingsGUI implements Listener {
           Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Right-Click Crop Harvest"));
       meta.lore(Arrays.asList(
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "Allows players to harvest crops by right-clicking them.",
+          "",
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
+              + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Left-Click: Toggle")
+          .stream().filter(Objects::nonNull).map(Component::text).collect(Collectors.toList()));
+      item.setItemMeta(meta);
+    }
+
+    return item;
+  }
+
+  private ItemStack _createNametagHealthItem() {
+    boolean state = _settingsManager.getNametagHealth();
+    ItemStack item = new ItemStack(Material.APPLE);
+    ItemMeta meta = item.getItemMeta();
+
+    if (meta != null) {
+      meta.displayName(
+          Component.text(ChatColor.RED + "" + ChatColor.BOLD + "» " + ChatColor.YELLOW + "Health Nametag"));
+      meta.lore(Arrays.asList(
+          ChatColor.YELLOW + "» " + ChatColor.GRAY + "Show player health under their nametag.",
           "",
           ChatColor.YELLOW + "» " + ChatColor.GRAY + "State: "
               + (state ? ChatColor.GREEN + "ENABLED" : ChatColor.RED + "DISABLED"),
@@ -608,6 +639,14 @@ public class AdminSettingsGUI implements Listener {
     String stateText = newState ? "ENABLED" : "DISABLED";
     p.sendMessage(
         Main.getPrefix() + "Right-Click crop harvest is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
+  }
+
+  private void _toggleNametagHealth(Player p) {
+    boolean newState = !_settingsManager.getNametagHealth();
+    _settingsManager.setNametagHealth(newState);
+    _plugin.getHealthDisplayManager().applyToAll(newState);
+    String stateText = newState ? "ENABLED" : "DISABLED";
+    p.sendMessage(Main.getPrefix() + "Health nametag is now " + ChatColor.YELLOW + ChatColor.BOLD + stateText);
   }
 
   private void _toggleAFKProtection(Player p) {

--- a/src/main/java/com/daveestar/bettervanilla/manager/HealthDisplayManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/HealthDisplayManager.java
@@ -1,0 +1,162 @@
+package com.daveestar.bettervanilla.manager;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TextDisplay;
+import org.bukkit.entity.Display;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Transformation;
+
+import com.daveestar.bettervanilla.Main;
+import com.daveestar.bettervanilla.manager.SettingsManager;
+
+import net.kyori.adventure.text.Component;
+
+public class HealthDisplayManager {
+  private static final float NORMAL_OFFSET = -0.25f;
+  private static final float SNEAK_OFFSET = -0.35f;
+
+  private final Main _plugin;
+  private SettingsManager _settingsManager;
+  private final Map<UUID, TextDisplay> _displays;
+  private final Map<UUID, BukkitTask> _pendingUpdates;
+
+  public HealthDisplayManager() {
+    _plugin = Main.getInstance();
+    _displays = new HashMap<>();
+    _pendingUpdates = new HashMap<>();
+  }
+
+  public void initManagers() {
+    _settingsManager = _plugin.getSettingsManager();
+    if (_settingsManager.getNametagHealth()) {
+      Bukkit.getOnlinePlayers().forEach(this::createDisplay);
+    }
+  }
+
+  public void applyToAll(boolean enabled) {
+    if (enabled) {
+      Bukkit.getOnlinePlayers().forEach(this::createDisplay);
+    } else {
+      _displays.values().forEach(TextDisplay::remove);
+      _displays.clear();
+      _pendingUpdates.values().forEach(BukkitTask::cancel);
+      _pendingUpdates.clear();
+    }
+  }
+
+  public void onPlayerJoined(Player p) {
+    if (_settingsManager.getNametagHealth()) {
+      createDisplay(p);
+    }
+  }
+
+  public void onPlayerLeft(Player p) {
+    removeDisplay(p);
+  }
+
+  public void onHealthChange(Player p) {
+    if (!_displays.containsKey(p.getUniqueId())) {
+      return;
+    }
+
+    BukkitTask task = _pendingUpdates.remove(p.getUniqueId());
+    if (task != null) {
+      task.cancel();
+    }
+
+    task = Bukkit.getScheduler().runTaskLater(_plugin, () -> {
+      TextDisplay display = _displays.get(p.getUniqueId());
+      if (display != null) {
+        display.text(Component.text(formatHealth(p)));
+      }
+      _pendingUpdates.remove(p.getUniqueId());
+    }, 2L);
+
+    _pendingUpdates.put(p.getUniqueId(), task);
+  }
+
+  public void onSneak(Player p, boolean sneaking) {
+    TextDisplay display = _displays.get(p.getUniqueId());
+    if (display == null) {
+      return;
+    }
+
+    Transformation transformation = display.getTransformation();
+    transformation.getTranslation().set(0f, sneaking ? SNEAK_OFFSET : NORMAL_OFFSET, 0f);
+    display.setTransformation(transformation);
+  }
+
+  public void onGameModeChange(Player p, GameMode newMode) {
+    if (newMode == GameMode.SPECTATOR) {
+      removeDisplay(p);
+    } else {
+      if (_settingsManager.getNametagHealth()) {
+        createDisplay(p);
+      }
+    }
+  }
+
+  public void onRespawn(Player p) {
+    removeDisplay(p);
+    if (_settingsManager.getNametagHealth()) {
+      Bukkit.getScheduler().runTask(_plugin, () -> createDisplay(p));
+    }
+  }
+
+  public void onWorldChange(Player p) {
+    removeDisplay(p);
+    if (_settingsManager.getNametagHealth()) {
+      Bukkit.getScheduler().runTask(_plugin, () -> createDisplay(p));
+    }
+  }
+
+  public void destroy() {
+    applyToAll(false);
+  }
+
+  private void createDisplay(Player p) {
+    if (p.getGameMode() == GameMode.SPECTATOR) {
+      return;
+    }
+    if (_displays.containsKey(p.getUniqueId())) {
+      return;
+    }
+
+    TextDisplay display = p.getWorld().spawn(p.getLocation(), TextDisplay.class, td -> {
+      td.text(Component.text(formatHealth(p)));
+      td.setBillboard(Display.Billboard.CENTER);
+      td.setViewRange(32f);
+      td.setShadowed(false);
+      td.setSeeThrough(true);
+      td.setBackgroundColor(null);
+      Transformation t = td.getTransformation();
+      t.getTranslation().set(0f, NORMAL_OFFSET, 0f);
+      td.setTransformation(t);
+    });
+    p.addPassenger(display);
+    _displays.put(p.getUniqueId(), display);
+  }
+
+  private void removeDisplay(Player p) {
+    TextDisplay display = _displays.remove(p.getUniqueId());
+    if (display != null) {
+      display.remove();
+    }
+    BukkitTask task = _pendingUpdates.remove(p.getUniqueId());
+    if (task != null) {
+      task.cancel();
+    }
+  }
+
+  private String formatHealth(Player p) {
+    double hearts = p.getHealth() / 2.0;
+    return String.format(java.util.Locale.US, "%.1f ❤", hearts);
+  }
+}
+

--- a/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
+++ b/src/main/java/com/daveestar/bettervanilla/manager/SettingsManager.java
@@ -202,6 +202,15 @@ public class SettingsManager {
     _config.save();
   }
 
+  public boolean getNametagHealth() {
+    return _fileConfig.getBoolean("global.nametaghealth", false);
+  }
+
+  public void setNametagHealth(boolean value) {
+    _fileConfig.set("global.nametaghealth", value);
+    _config.save();
+  }
+
   public boolean getBackpackEnabled() {
     return _fileConfig.getBoolean("global.backpack.enabled", false);
   }


### PR DESCRIPTION
## Summary
- add configurable health display below player nametag using TextDisplay passengers
- expose toggle in admin settings and persist in settings config
- manage creation/updates/cleanup of displays through a new HealthDisplayManager

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68906fc64f808320b449532c572326d7